### PR TITLE
Revert addition of auto mode, heat_cool is more appropriate

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ was the primary inspiration and guide for building this ESPHome component.
 ## Features
 
 - Setpoint temperature.
-- Climate modes AUTO, OFF, COOL, HEAT, DRY, FAN, and HEAT_COOL.
+- Climate modes OFF, HEAT_COOL, COOL, HEAT, FAN_ONLY and DRY.
 - Fan modes auto, silent and 1-5.
 - Swing modes horizontal, vertical, and both.
 
@@ -77,7 +77,7 @@ uart:
 daikin_s21:
   tx_uart: s21_uart
   rx_uart: s21_uart
-  supported_modes:  # auto and off are always supported
+  supported_modes:  # off and heat_cool are always supported
     - cool
     - heat
     - dry

--- a/components/daikin_s21/climate/__init__.py
+++ b/components/daikin_s21/climate/__init__.py
@@ -25,11 +25,11 @@ UARTComponent = uart_ns.class_("UARTComponent")
 
 SUPPORTED_CLIMATE_MODES_OPTIONS = {
     "OFF": ClimateMode.CLIMATE_MODE_OFF,  # always available
-    "AUTO": ClimateMode.CLIMATE_MODE_AUTO,  # always available
+    "HEAT_COOL": ClimateMode.CLIMATE_MODE_HEAT_COOL,  # always available
     "COOL": ClimateMode.CLIMATE_MODE_COOL,
     "HEAT": ClimateMode.CLIMATE_MODE_HEAT,
-    "DRY": ClimateMode.CLIMATE_MODE_DRY,
     "FAN_ONLY": ClimateMode.CLIMATE_MODE_FAN_ONLY,
+    "DRY": ClimateMode.CLIMATE_MODE_DRY,
 }
 
 CONFIG_SCHEMA = cv.All(
@@ -68,6 +68,6 @@ async def to_code(config):
         cg.add(var.set_supported_modes([
             ClimateMode.CLIMATE_MODE_COOL,
             ClimateMode.CLIMATE_MODE_HEAT,
-            ClimateMode.CLIMATE_MODE_DRY,
             ClimateMode.CLIMATE_MODE_FAN_ONLY,
+            ClimateMode.CLIMATE_MODE_DRY,
         ]))

--- a/components/daikin_s21/climate/daikin_s21_climate.h
+++ b/components/daikin_s21/climate/daikin_s21_climate.h
@@ -11,18 +11,6 @@
 namespace esphome {
 namespace daikin_s21 {
 
-// clang-format off
-static const climate::ClimateMode OpModes[] = {
-    climate::CLIMATE_MODE_OFF,  // Unused
-    climate::CLIMATE_MODE_HEAT_COOL,
-    climate::CLIMATE_MODE_DRY,
-    climate::CLIMATE_MODE_COOL,
-    climate::CLIMATE_MODE_HEAT,
-    climate::CLIMATE_MODE_OFF,  // Unused
-    climate::CLIMATE_MODE_FAN_ONLY
-};
-// clang-format on
-
 class DaikinS21Climate : public climate::Climate,
                          public PollingComponent,
                          public DaikinS21Client {
@@ -40,9 +28,6 @@ class DaikinS21Climate : public climate::Climate,
   float get_room_temp_offset();
 
   bool should_check_setpoint(climate::ClimateMode mode);
-  climate::ClimateAction d2e_climate_action();
-  climate::ClimateMode d2e_climate_mode(DaikinClimateMode mode);
-  DaikinClimateMode e2d_climate_mode(climate::ClimateMode mode);
   const std::string d2e_fan_mode(DaikinFanMode mode);
   DaikinFanMode e2d_fan_mode(std::string mode);
   climate::ClimateSwingMode d2e_swing_mode(bool swing_v, bool swing_h);
@@ -76,7 +61,7 @@ class DaikinS21Climate : public climate::Climate,
   void save_setpoint(float value, ESPPreferenceObject &pref);
   void save_setpoint(float value);
   optional<float> load_setpoint(ESPPreferenceObject &pref);
-  optional<float> load_setpoint(DaikinClimateMode mode);
+  optional<float> load_setpoint();
   void set_s21_climate();
 };
 


### PR DESCRIPTION
CLIMATE_MODE_HEAT_COOL: The climate device is set to heat/cool to reach the target temperature.
CLIMATE_MODE_AUTO: The climate device is adjusting the temperature dynamically. For example, the target temperature can be adjusted based on a schedule, or learned behavior. The target temperature can't be adjusted when in this mode.

Use ESPHome ClimateMode and ClimateAction enumerations directly in s21 control code. HVAC unit reports actions in heat_cool mode in a way that didn't line up with the DaikinClimateMode

Remove mode parameter from load_setpoint, it's always passed the same value and accessible from the function

fixes #5 