### PR TITLE
Fix climate action reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,19 @@
 ESPHome component to control Daikin indoor mini-split units with s21 ports.
 
 Many thanks to the work by [revk][1] on the fantastic [Faikin][2] project, which
-was the primary inspiration and guide for building this ESPHome component.
+was the primary inspiration and guide for building this ESPHome component. In 
+addition, the very active and resourceful community that project has fostered
+that has decoded much of the protocol.
+
+A huge thanks to [joshbenner][4], the original author of this integration. His
+[repository][5] would be my preferred place to commit patches to avoid
+fragmentation, but he lacks the time at the moment to manage the project.
 
 ## Features
 
 - Setpoint temperature.
 - Climate modes OFF, HEAT_COOL, COOL, HEAT, FAN_ONLY and DRY.
+- Independent climate action reporting. See what your unit is trying to do, e.g. heating while in HEAT_COOL.
 - Fan modes auto, silent and 1-5.
 - Swing modes horizontal, vertical, and both.
 
@@ -17,9 +24,13 @@ Sensors:
 * Outside temperature (outside exchanger)
 * Coil temperature (indoor air handler's coil)
 * Fan speed
-* Vertical swing angle (directional louver)
-* Compressor frequency
-  * Note: I have no way to verify no scaling is to be applied to this value, implementation taken from the Faikin project. Open an issue if you can independently measure it.
+* Vertical swing angle (directional flap)
+* Compressor frequency (outside exchanger)
+* Humidity (not supported on all units, will report a consistent 50% if not present)
+
+On multihead systems the outdoor values will be the same (accounting for sampling jitter). It
+could be cleaner to only configure these sensors on your "primary" ESPhome device. One day
+I might look at splitting these off into a separate component.
 
 ## Limitations
 
@@ -27,6 +38,7 @@ Sensors:
 * Does not detect nor support powerful or econo modes.
 * Does not support comfort or presence detection features on some models.
 * Does not interact with the indoor units schedules (do that with HA instead).
+* Currently targets Version 0 protocol support due to the equipment available to the author.
 
 ## Hardware
 
@@ -56,6 +68,8 @@ on having pins inverted differently.
 [1]: https://github.com/revk
 [2]: https://github.com/revk/ESP32-Faikin
 [3]: https://github.com/revk/ESP32-Faikin/tree/main/PCB/Faikin
+[4]: https://github.com/joshbenner
+[5]: https://github.com/joshbenner/esphome-daikin-s21
 
 ## Configuration Example
 
@@ -90,7 +104,7 @@ climate:
   - name: My Daikin
     platform: daikin_s21
     visual:
-      target_temperature: 1
+      target_temperature: 1 # My unit supports 1 degree granularity while the protocol supports 0.5
       current_temperature: 0.5
     # Optional HA sensor used to alter setpoint.
     room_temperature_sensor: room_temp  # See homeassistant sensor below
@@ -110,6 +124,8 @@ sensor:
       name: Swing Vertical Angle
     compressor_frequency:
       name: Compressor Frequency
+    humidity:
+      name: Humidity
   - platform: homeassistant
     id: room_temp
     entity_id: sensor.office_temperature

--- a/components/daikin_s21/__init__.py
+++ b/components/daikin_s21/__init__.py
@@ -11,6 +11,7 @@ DEPENDENCIES = ["uart"]
 CONF_TX_UART = "tx_uart"
 CONF_RX_UART = "rx_uart"
 CONF_S21_ID = "s21_id"
+CONF_DEBUG_COMMS = "debug_comms"
 CONF_DEBUG_PROTOCOL = "debug_protocol"
 
 daikin_s21_ns = cg.esphome_ns.namespace("daikin_s21")
@@ -24,6 +25,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.GenerateID(): cv.declare_id(DaikinS21),
         cv.Required(CONF_TX_UART): cv.use_id(UARTComponent),
         cv.Required(CONF_RX_UART): cv.use_id(UARTComponent),
+        cv.Optional(CONF_DEBUG_COMMS, default=False): cv.boolean,
         cv.Optional(CONF_DEBUG_PROTOCOL, default=False): cv.boolean,
     }
 ).extend(cv.polling_component_schema("2s"))
@@ -34,7 +36,6 @@ S21_CLIENT_SCHEMA = cv.Schema(
     }
 )
 
-
 async def to_code(config):
     """Generate code"""
     var = cg.new_Pvariable(config[CONF_ID])
@@ -42,4 +43,5 @@ async def to_code(config):
     tx_uart = await cg.get_variable(config[CONF_TX_UART])
     rx_uart = await cg.get_variable(config[CONF_RX_UART])
     cg.add(var.serial.set_uarts(tx_uart, rx_uart))
+    cg.add(var.set_debug_comms(config[CONF_DEBUG_COMMS]))
     cg.add(var.set_debug_protocol(config[CONF_DEBUG_PROTOCOL]))

--- a/components/daikin_s21/sensor/__init__.py
+++ b/components/daikin_s21/sensor/__init__.py
@@ -6,14 +6,18 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import sensor
 from esphome.const import (
+    CONF_HUMIDITY,
     CONF_ID,
     UNIT_CELSIUS,
     UNIT_DEGREES,
     UNIT_HERTZ,
+    UNIT_PERCENT,
     UNIT_REVOLUTIONS_PER_MINUTE,
     ICON_FAN,
     ICON_THERMOMETER,
+    ICON_WATER_PERCENT,
     DEVICE_CLASS_FREQUENCY,
+    DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_TEMPERATURE,
     STATE_CLASS_MEASUREMENT,
 )
@@ -82,6 +86,13 @@ CONFIG_SCHEMA = (
                 device_class=DEVICE_CLASS_FREQUENCY,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
+            cv.Optional(CONF_HUMIDITY): sensor.sensor_schema(
+                unit_of_measurement=UNIT_PERCENT,
+                icon=ICON_WATER_PERCENT,
+                accuracy_decimals=0,
+                device_class=DEVICE_CLASS_HUMIDITY,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
         }
     )
     .extend(S21_CLIENT_SCHEMA)
@@ -120,3 +131,7 @@ async def to_code(config):
     if CONF_COMPRESSOR_FREQUENCY in config:
         sens = await sensor.new_sensor(config[CONF_COMPRESSOR_FREQUENCY])
         cg.add(var.set_compressor_frequency_sensor(sens))
+    
+    if CONF_HUMIDITY in config:
+        sens = await sensor.new_sensor(config[CONF_HUMIDITY])
+        cg.add(var.set_humidity_sensor(sens))

--- a/components/daikin_s21/sensor/daikin_s21_sensor.cpp
+++ b/components/daikin_s21/sensor/daikin_s21_sensor.cpp
@@ -26,6 +26,9 @@ void DaikinS21Sensor::update() {
   if (this->compressor_frequency_sensor_ != nullptr) {
     this->compressor_frequency_sensor_->publish_state(this->s21->get_compressor_frequency());
   }
+  if (this->humidity_sensor_ != nullptr) {
+    this->humidity_sensor_->publish_state(this->s21->get_humidity());
+  }
 }
 
 void DaikinS21Sensor::dump_config() {
@@ -36,6 +39,7 @@ void DaikinS21Sensor::dump_config() {
   LOG_SENSOR("  ", "Fan Speed", this->fan_speed_sensor_);
   LOG_SENSOR("  ", "Swing Vertical Angle", this->swing_vertical_angle_sensor_);
   LOG_SENSOR("  ", "Compressor Frequency", this->compressor_frequency_sensor_);
+  LOG_SENSOR("  ", "Humidity", this->humidity_sensor_);
 }
 
 }  // namespace daikin_s21

--- a/components/daikin_s21/sensor/daikin_s21_sensor.h
+++ b/components/daikin_s21/sensor/daikin_s21_sensor.h
@@ -29,6 +29,9 @@ class DaikinS21Sensor : public PollingComponent, public DaikinS21Client {
   void set_compressor_frequency_sensor(sensor::Sensor *sensor) {
     this->compressor_frequency_sensor_ = sensor;
   }
+  void set_humidity_sensor(sensor::Sensor *sensor) {
+    this->humidity_sensor_ = sensor;
+  }
 
  protected:
   sensor::Sensor *temp_inside_sensor_{nullptr};
@@ -37,6 +40,7 @@ class DaikinS21Sensor : public PollingComponent, public DaikinS21Client {
   sensor::Sensor *fan_speed_sensor_{nullptr};
   sensor::Sensor *swing_vertical_angle_sensor_{nullptr};
   sensor::Sensor *compressor_frequency_sensor_{nullptr};
+  sensor::Sensor *humidity_sensor_{nullptr};
 };
 
 }  // namespace daikin_s21


### PR DESCRIPTION
Read out internal target temperature to determine action idleness

Also:
* Update README
* Add humidity sensor readout
* Add protocol detection. Works for me with my version 0 units.
* Remove RH and Ra fan mode detection, protocol 0 supports these
* Remove a couple readiness flags. It's going to get too cumbersome to flag them all. Eventually maybe make use of std::optional and only publish ready values or something.

fixes #14 