### PR TITLE
Use C10 format for setpoint

### DIFF
--- a/components/daikin_s21/__init__.py
+++ b/components/daikin_s21/__init__.py
@@ -28,7 +28,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_DEBUG_COMMS, default=False): cv.boolean,
         cv.Optional(CONF_DEBUG_PROTOCOL, default=False): cv.boolean,
     }
-).extend(cv.polling_component_schema("2s"))
+).extend(cv.polling_component_schema("30s"))
 
 S21_CLIENT_SCHEMA = cv.Schema(
     {

--- a/components/daikin_s21/s21.h
+++ b/components/daikin_s21/s21.h
@@ -71,7 +71,7 @@ private:
 
 struct DaikinSettings {
   climate::ClimateMode mode = climate::CLIMATE_MODE_OFF;
-  int16_t setpoint = 23;
+  int16_t setpoint = 23 * 10;
   DaikinFanMode fan = DaikinFanMode::Auto;
   climate::ClimateSwingMode swing = climate::CLIMATE_SWING_OFF;
 };
@@ -89,18 +89,16 @@ class DaikinS21 : public PollingComponent {
   void set_debug_comms(bool set) { this->serial.debug = set; }
   void set_debug_protocol(bool set) { this->debug_protocol = set; }
 
-  bool is_ready() { return this->ready.all(); }
-
-  DaikinFanMode get_fan_mode() { return this->active.fan; }
-  float get_setpoint() { return this->active.setpoint / 10.0; }
-  esphome::climate::ClimateSwingMode get_swing_mode() { return this->active.swing; }
-
   // external command actions
   void set_daikin_climate_settings(climate::ClimateMode mode, float setpoint, DaikinFanMode fan_mode);
   void set_swing_settings(climate::ClimateSwingMode swing);
 
+  bool is_ready() { return this->ready.all(); }
   climate::ClimateMode get_climate_mode() { return this->active.mode; }
   climate::ClimateAction get_climate_action();
+  DaikinFanMode get_fan_mode() { return this->active.fan; }
+  climate::ClimateSwingMode get_swing_mode() { return this->active.swing; }
+  float get_setpoint() { return this->active.setpoint / 10.0F; }
   float get_temp_inside() { return this->temp_inside / 10.0; }
   float get_temp_outside() { return this->temp_outside / 10.0; }
   float get_temp_coil() { return this->temp_coil / 10.0; }


### PR DESCRIPTION
- remove now-pointless rounding from setpoint set in D1
- remove some floating point operations
- fix unused RC interpretation
- reduce default core polling rate to 30s. communication is working well, no need to clutter up debug logs.