### PR TITLE
Climate traits polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ fragmentation, but he lacks the time at the moment to manage the project.
 
 ## Features
 
+Climate:
 - Setpoint temperature.
-- Climate modes OFF, HEAT_COOL, COOL, HEAT, FAN_ONLY and DRY.
+- Selectable climate modes OFF, HEAT_COOL, COOL, HEAT, FAN_ONLY and DRY.
 - Independent climate action reporting. See what your unit is trying to do, e.g. heating while in HEAT_COOL.
 - Fan modes auto, silent and 1-5.
 - Swing modes horizontal, vertical, and both.
+- Optional humidity reporting.
 
 Sensors:
 * Inside temperature (usually measured at indoor air handler return)
@@ -30,12 +32,13 @@ Sensors:
 * Unit demand from compressor with configurable scaling factor
 
 On multihead systems the outdoor values will be the same (accounting for sampling jitter). It
-could be cleaner to only configure these sensors on your "primary" ESPhome device. One day
-I might look at splitting these off into a separate component.
+could be cleaner to only configure these sensors on your "primary" ESPhome device. ESPHome is
+adding support for multiple devices, when this is release I will document how to do this.
 
 ## Limitations
 
 * This code has only been tested on ESP32 pico and ESP32-S3.
+* Tested with 4MXl36TVJU outdoor unit and CTXS07LVJU, FTXS12LVJU, FTXS15LVJU indoor units.
 * Does not detect nor support powerful or econo modes.
 * Does not support comfort or presence detection features on some models.
 * Does not interact with the indoor units schedules (do that with HA instead).
@@ -95,20 +98,23 @@ uart:
 daikin_s21:
   tx_uart: s21_uart
   rx_uart: s21_uart
-  supported_modes:  # off and heat_cool are always supported
-    - cool
-    - heat
-    - dry
-    - fan_only
 
 climate:
   - name: My Daikin
     platform: daikin_s21
-    visual:
-      target_temperature: 1 # My unit supports 1 degree granularity while the protocol supports 0.5
-      current_temperature: 0.5
+    # Settings from ESPHome Climate component:
+    # visual:
+    #   target_temperature: 1
+    #   current_temperature: 0.5
+    # Settings from DaikinS21Climate:
+    supports_humidity: true # If your unit supports humidity, it can be reported in the climate component
     # Optional HA sensor used to alter setpoint.
     room_temperature_sensor: room_temp  # See homeassistant sensor below
+    supported_modes:  # off and heat_cool are always supported
+      - cool
+      - heat
+      - dry
+      - fan_only
 
 # Optional additional sensors.
 sensor:

--- a/components/daikin_s21/__init__.py
+++ b/components/daikin_s21/__init__.py
@@ -42,6 +42,6 @@ async def to_code(config):
     await cg.register_component(var, config)
     tx_uart = await cg.get_variable(config[CONF_TX_UART])
     rx_uart = await cg.get_variable(config[CONF_RX_UART])
-    cg.add(var.serial.set_uarts(tx_uart, rx_uart))
+    cg.add(var.set_uarts(tx_uart, rx_uart))
     cg.add(var.set_debug_comms(config[CONF_DEBUG_COMMS]))
     cg.add(var.set_debug_protocol(config[CONF_DEBUG_PROTOCOL]))

--- a/components/daikin_s21/climate/__init__.py
+++ b/components/daikin_s21/climate/__init__.py
@@ -6,7 +6,9 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import climate, sensor
 from esphome.components.climate import ClimateMode
-from esphome.const import CONF_SUPPORTED_MODES
+from esphome.const import (
+    CONF_SUPPORTED_MODES,
+)
 from .. import (
     daikin_s21_ns,
     CONF_S21_ID,
@@ -15,13 +17,12 @@ from .. import (
 )
 
 CONF_ROOM_TEMPERATURE_SENSOR = "room_temperature_sensor"
+CONF_SUPPORTS_HUMIDITY = "supports_humidity"
 CONF_SETPOINT_INTERVAL = "setpoint_interval"
 
 DaikinS21Climate = daikin_s21_ns.class_(
     "DaikinS21Climate", climate.Climate, cg.PollingComponent, DaikinS21Client
 )
-uart_ns = cg.esphome_ns.namespace("uart")
-UARTComponent = uart_ns.class_("UARTComponent")
 
 SUPPORTED_CLIMATE_MODES_OPTIONS = {
     "OFF": ClimateMode.CLIMATE_MODE_OFF,  # always available
@@ -37,18 +38,16 @@ CONFIG_SCHEMA = cv.All(
     .extend(
         {
             cv.Optional(CONF_ROOM_TEMPERATURE_SENSOR): cv.use_id(sensor.Sensor),
-            cv.Optional(
-                CONF_SETPOINT_INTERVAL, default="300s"
-            ): cv.positive_time_period_seconds,
+            cv.Optional(CONF_SETPOINT_INTERVAL, default="300s"): cv.positive_time_period_seconds,
             cv.Optional(CONF_SUPPORTED_MODES): cv.ensure_list(
                 cv.enum(SUPPORTED_CLIMATE_MODES_OPTIONS, upper=True)
             ),
+            cv.Optional(CONF_SUPPORTS_HUMIDITY): cv.boolean,
         }
     )
     .extend(cv.polling_component_schema("5s"))
     .extend(S21_CLIENT_SCHEMA)
 )
-
 
 async def to_code(config):
     """Generate code"""
@@ -56,6 +55,7 @@ async def to_code(config):
     await cg.register_component(var, config)
     s21_var = await cg.get_variable(config[CONF_S21_ID])
     cg.add(var.set_s21(s21_var))
+
     if CONF_ROOM_TEMPERATURE_SENSOR in config:
         sens = await cg.get_variable(config[CONF_ROOM_TEMPERATURE_SENSOR])
         cg.add(var.set_room_sensor(sens))
@@ -63,11 +63,7 @@ async def to_code(config):
             cg.add(var.set_setpoint_interval(config[CONF_SETPOINT_INTERVAL]))
 
     if CONF_SUPPORTED_MODES in config:
-        cg.add(var.set_supported_modes(config[CONF_SUPPORTED_MODES]))
-    else:
-        cg.add(var.set_supported_modes([
-            ClimateMode.CLIMATE_MODE_COOL,
-            ClimateMode.CLIMATE_MODE_HEAT,
-            ClimateMode.CLIMATE_MODE_FAN_ONLY,
-            ClimateMode.CLIMATE_MODE_DRY,
-        ]))
+        cg.add(var.set_supported_modes_override(config[CONF_SUPPORTED_MODES]))
+    
+    if CONF_SUPPORTS_HUMIDITY in config:
+        cg.add(var.set_supports_current_humidity(config[CONF_SUPPORTS_HUMIDITY]))

--- a/components/daikin_s21/climate/daikin_s21_climate.h
+++ b/components/daikin_s21/climate/daikin_s21_climate.h
@@ -29,10 +29,13 @@ class DaikinS21Climate : public climate::Climate,
 
   bool should_check_setpoint(climate::ClimateMode mode);
 
-  void set_supported_modes(const std::set<esphome::climate::ClimateMode> &modes);
+  void set_supported_modes_override(std::set<climate::ClimateMode> modes) { this->supported_modes_override_ = std::move(modes); }
+  void set_supports_current_humidity(bool supports_current_humidity) { this->supports_current_humidity_ = supports_current_humidity; }
 
  protected:
-  esphome::climate::ClimateTraits traits_;
+  climate::ClimateTraits traits() override;
+  optional<std::set<climate::ClimateMode>> supported_modes_override_{};
+  bool supports_current_humidity_{false};
 
   sensor::Sensor *room_sensor_{nullptr};
   float expected_s21_setpoint;
@@ -43,8 +46,6 @@ class DaikinS21Climate : public climate::Climate,
   ESPPreferenceObject auto_setpoint_pref;
   ESPPreferenceObject cool_setpoint_pref;
   ESPPreferenceObject heat_setpoint_pref;
-
-  climate::ClimateTraits traits() override;
 
   bool use_room_sensor();
   bool room_sensor_unit_is_valid();

--- a/components/daikin_s21/climate/daikin_s21_climate.h
+++ b/components/daikin_s21/climate/daikin_s21_climate.h
@@ -28,8 +28,6 @@ class DaikinS21Climate : public climate::Climate,
   float get_room_temp_offset();
 
   bool should_check_setpoint(climate::ClimateMode mode);
-  const std::string d2e_fan_mode(DaikinFanMode mode);
-  DaikinFanMode e2d_fan_mode(std::string mode);
 
   void set_supported_modes(const std::set<esphome::climate::ClimateMode> &modes);
 

--- a/components/daikin_s21/daikin_s21_fan_modes.h
+++ b/components/daikin_s21/daikin_s21_fan_modes.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <cstdint>
+#include "esphome/core/string_ref.h"
+
+namespace esphome {
+namespace daikin_s21 {
+
+enum class DaikinFanMode : uint8_t {
+  Auto = 'A',
+  Silent = 'B',
+  Speed1 = '3',
+  Speed2 = '4',
+  Speed3 = '5',
+  Speed4 = '6',
+  Speed5 = '7',
+};
+
+static constexpr DaikinFanMode supported_daikin_fan_modes[] = {
+  DaikinFanMode::Auto,
+  DaikinFanMode::Silent,
+  DaikinFanMode::Speed1,
+  DaikinFanMode::Speed2,
+  DaikinFanMode::Speed3,
+  DaikinFanMode::Speed4,
+  DaikinFanMode::Speed5,
+};
+
+constexpr StringRef daikin_fan_mode_to_string_ref(const DaikinFanMode mode) {
+  switch (mode) {
+    case DaikinFanMode::Auto:
+    default:
+      return StringRef::from_lit("Automatic");
+    case DaikinFanMode::Silent:
+      return StringRef::from_lit("Silent");
+    case DaikinFanMode::Speed1:
+      return StringRef::from_lit("1");
+    case DaikinFanMode::Speed2:
+      return StringRef::from_lit("2");
+    case DaikinFanMode::Speed3:
+      return StringRef::from_lit("3");
+    case DaikinFanMode::Speed4:
+      return StringRef::from_lit("4");
+    case DaikinFanMode::Speed5:
+      return StringRef::from_lit("5");
+  }
+}
+
+constexpr DaikinFanMode string_to_daikin_fan_mode(const std::string &mode) {
+  for (const auto supported_mode : supported_daikin_fan_modes) {
+    if (daikin_fan_mode_to_string_ref(supported_mode) == mode) {
+      return supported_mode;
+    }
+  }
+  return DaikinFanMode::Auto;
+}
+
+}  // namespace daikin_s21
+}  // namespace esphome


### PR DESCRIPTION
Clean up climate traits, structure like other integrations

- Create ClimateTraits on the stack, override, return to Climate::get_traits() to override further
- Set a couple defaults to avoid having to configure them in yaml (temperature steps and limits)
- Delete a few unused variables the compiler never warned me about...?
- Add configurable option to report current humidity in the Climate component
- Move custom fan modes to separate header, used by climate and core logic
- Deduplicate fan mode -> string lookup
- Build set_supported_custom_fan_modes set from common definition
- Make DaikinSerial member protected, reduce scope of a couple helper functions
- Fix README documentation for `supported_modes`