### PR TITLE
Climate component publishing improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Sensors:
 
 On multihead systems the outdoor values will be the same (accounting for sampling jitter). It
 could be cleaner to only configure these sensors on your "primary" ESPhome device. ESPHome is
-adding support for multiple devices, when this is release I will document how to do this.
+adding support for multiple devices, when this is released I will document how to do this.
 
 ## Limitations
 
@@ -60,7 +60,7 @@ On my Daikin units, the S21 port has the following pins:
 * 5 - GND
 
 The S21 plug is JST `EHR-5` and related header `B5B-EH-A(LF)(SN)`, though the
-plug pins are at standard pin header widths.
+plug pins are at standard 2.5mm pin header widths.
 
 ### PCB
 
@@ -110,6 +110,7 @@ climate:
     supports_humidity: true # If your unit supports humidity, it can be reported in the climate component
     # Optional HA sensor used to alter setpoint.
     room_temperature_sensor: room_temp  # See homeassistant sensor below
+    setpoint_interval: 300s # Interval used to adjust the unit's setpoint if the room temperature sensor is specified
     supported_modes:  # off and heat_cool are always supported
       - cool
       - heat

--- a/components/daikin_s21/climate/__init__.py
+++ b/components/daikin_s21/climate/__init__.py
@@ -45,7 +45,6 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_SUPPORTS_HUMIDITY): cv.boolean,
         }
     )
-    .extend(cv.polling_component_schema("5s"))
     .extend(S21_CLIENT_SCHEMA)
 )
 

--- a/components/daikin_s21/climate/__init__.py
+++ b/components/daikin_s21/climate/__init__.py
@@ -21,7 +21,7 @@ CONF_SUPPORTS_HUMIDITY = "supports_humidity"
 CONF_SETPOINT_INTERVAL = "setpoint_interval"
 
 DaikinS21Climate = daikin_s21_ns.class_(
-    "DaikinS21Climate", climate.Climate, cg.PollingComponent, DaikinS21Client
+    "DaikinS21Climate", climate.Climate, cg.Component, DaikinS21Client
 )
 
 SUPPORTED_CLIMATE_MODES_OPTIONS = {

--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -20,11 +20,99 @@ void DaikinS21Climate::setup() {
   auto_setpoint_pref = global_preferences->make_preference<int16_t>(h + 1);
   cool_setpoint_pref = global_preferences->make_preference<int16_t>(h + 2);
   heat_setpoint_pref = global_preferences->make_preference<int16_t>(h + 3);
+  this->set_custom_fan_mode(commanded.fan); // ensure custom fan mode string is populated with a default
+}
+
+/**
+ * Component polling loop.
+ * 
+ * Check the DaikinS21 component to see if it's updated.
+ * Update climate state if a previous command isn't in progress.
+ * Publish any state changes to Home Assistant.
+ */
+void DaikinS21Climate::loop() {
+  if (this->s21->climate_updated) {
+    const auto& reported = this->s21->get_climate_settings();
+
+    // New state, determine if we can publish
+    const bool can_publish = (static_cast<int32_t>(millis() - this->command_timeout_end_ms) >= 0) ||  // command not in progress
+                             (this->commanded == reported);                         // command took effect, no longer in progress
+    if (can_publish) {
+      // Clear the updated flag only if there's no command in progress.
+      // A command timeout could occur before the next update and we'd want to publish the current state
+      this->s21->climate_updated = false;
+      this->command_timeout_end_ms = millis(); // move forward to avoid underflow in subsequent expiry calculations
+
+      // Allowed to publish, determine if we should
+      bool do_publish = false;
+
+      // Detect and integrate new sensor values into component state
+      if ((this->current_temperature != this->get_effective_current_temperature()) ||
+          (this->current_humidity != this->s21->get_humidity()) ||
+          (this->action != this->s21->get_climate_action())) {
+        this->action = this->s21->get_climate_action();
+        this->current_temperature = this->get_effective_current_temperature();
+        this->current_humidity = this->s21->get_humidity();
+        do_publish = true;
+      }
+
+      // Detect and integrate new settings values into component state
+      if (this->should_check_setpoint()) {
+        this->last_setpoint_check_ms = millis();
+
+        if (this->use_room_sensor()) {
+          ESP_LOGD(TAG, "Room temp from external sensor: %.1f %s (%.1f °C)",
+                  this->room_sensor_->get_state(),
+                  this->room_sensor_->get_unit_of_measurement().c_str(),
+                  this->room_sensor_degc());
+          ESP_LOGD(TAG, "  Offset: %.1f", this->get_room_temp_offset());
+        }
+
+        // Target temperature is stored by climate class, and is used to represent
+        // the user's desired temperature. This is distinct from the HVAC unit's
+        // setpoint because we may be using an external sensor. So we only update
+        // the target temperature here if it appears uninitialized.
+        float unexpected_diff = abs(this->commanded.setpoint.f_degc() - reported.setpoint.f_degc());
+        if (this->target_temperature == 0.0F || isnanf(this->target_temperature)) {
+          // Use stored setpoint for mode, or fall back to use s21's setpoint.
+          this->target_temperature = this->load_setpoint().value_or(reported.setpoint.f_degc());
+          this->set_s21_climate();
+        } else if (unexpected_diff >= SETPOINT_STEP) {
+          // User probably set temp via IR remote -- so try to honor their wish by
+          // matching controller's target value to what they sent via remote.
+          ESP_LOGI(TAG, "S21 setpoint changed outside controller, updating target temp (expected %.1f, found %.1f)",
+              this->commanded.setpoint.f_degc(), reported.setpoint.f_degc());
+          this->target_temperature = reported.setpoint.f_degc();
+          this->set_s21_climate();
+        } else if (this->s21_setpoint_variance() >= SETPOINT_STEP) {
+          // Room temperature offset has probably changed, so we need to adjust
+          // the s21 setpoint based on the new difference.
+          this->set_s21_climate();
+          ESP_LOGI(TAG, "S21 setpoint updated to %.1f", this->commanded.setpoint.f_degc());
+        }
+      }
+
+      // If the resulting commanded settings of the above are currently being reported, there's no update to publish
+      if (this->commanded != reported) {
+        if (this->commanded.fan != reported.fan) {
+          this->set_custom_fan_mode(reported.fan);   // avoid custom string operations until there's a change that requires publishing
+        }
+        this->mode = reported.mode;
+        this->swing_mode = reported.swing;
+        this->commanded = reported;
+        do_publish = true;
+      }
+
+      // Only publish when state changed
+      if (do_publish) {
+        this->publish_state();
+      }
+    }
+  }
 }
 
 void DaikinS21Climate::dump_config() {
   ESP_LOGCONFIG(TAG, "DaikinS21Climate:");
-  ESP_LOGCONFIG(TAG, "  Update interval: %" PRIu32, this->get_update_interval());
   if (this->room_sensor_ != nullptr) {
     if (!this->room_sensor_unit_is_valid()) {
       ESP_LOGCONFIG(TAG, "  ROOM SENSOR: INVALID UNIT '%s' (must be °C or °F)",
@@ -32,7 +120,7 @@ void DaikinS21Climate::dump_config() {
     } else {
       ESP_LOGCONFIG(TAG, "  Room sensor: %s",
                     this->room_sensor_->get_name().c_str());
-      ESP_LOGCONFIG(TAG, "  Setpoint interval: %d", this->setpoint_interval);
+      ESP_LOGCONFIG(TAG, "  Setpoint interval: %ds", this->setpoint_interval_s);
     }
   }
   this->dump_traits_(TAG);
@@ -47,7 +135,6 @@ climate::ClimateTraits DaikinS21Climate::traits() {
   traits.set_visual_max_temperature(32.0F);
   traits.set_visual_current_temperature_step(0.5F);
   traits.set_visual_target_temperature_step(1.0F);
-
   traits.set_supported_modes({
       climate::CLIMATE_MODE_OFF,
       climate::CLIMATE_MODE_HEAT_COOL,
@@ -56,30 +143,30 @@ climate::ClimateTraits DaikinS21Climate::traits() {
       climate::CLIMATE_MODE_FAN_ONLY,
       climate::CLIMATE_MODE_DRY,
   });
-
   std::array<std::string, std::size(supported_daikin_fan_modes)> supported_fan_mode_strings;
   std::transform(std::begin(supported_daikin_fan_modes), std::end(supported_daikin_fan_modes), std::begin(supported_fan_mode_strings), [](const auto &arg){ return daikin_fan_mode_to_string_ref(arg).str(); } );
   traits.set_supported_custom_fan_modes({std::begin(supported_fan_mode_strings), std::end(supported_fan_mode_strings)});
-
   traits.set_supported_swing_modes({
       climate::CLIMATE_SWING_OFF,
       climate::CLIMATE_SWING_BOTH,
       climate::CLIMATE_SWING_VERTICAL,
       climate::CLIMATE_SWING_HORIZONTAL,
   });
-
   // Overrides
   if (this->supports_current_humidity_) {
     traits.set_supports_current_humidity(this->supports_current_humidity_);
   }
-
   if (this->supported_modes_override_.has_value()) {
     traits.set_supported_modes(this->supported_modes_override_.value());
     traits.add_supported_mode(climate::CLIMATE_MODE_OFF);   // Always available
     traits.add_supported_mode(climate::CLIMATE_MODE_HEAT_COOL);  // Always available
   }
-
   return traits;
+}
+
+void DaikinS21Climate::set_custom_fan_mode(const DaikinFanMode mode) {
+  this->commanded.fan = mode;
+  this->custom_fan_mode = daikin_fan_mode_to_string_ref(mode).str(); 
 }
 
 bool DaikinS21Climate::use_room_sensor() {
@@ -112,7 +199,7 @@ float DaikinS21Climate::get_effective_current_temperature() {
 
 float DaikinS21Climate::get_room_temp_offset() {
   if (!this->use_room_sensor()) {
-    return 0.0;
+    return 0.0F;
   }
   float room_val = this->room_sensor_degc();
   float s21_val = this->s21->get_temp_inside();
@@ -124,26 +211,25 @@ float nearest_step(float temp) {
 }
 
 // What setpoint should be sent to s21, acconting for external room sensor.
-float DaikinS21Climate::calc_s21_setpoint(float target) {
-  float offset_target = target + this->get_room_temp_offset();
+float DaikinS21Climate::calc_s21_setpoint() {
+  float offset_target = this->target_temperature + this->get_room_temp_offset();
   return nearest_step(offset_target);
 }
 
 // How far from desired setpoint is the current S21 setpoint?
 float DaikinS21Climate::s21_setpoint_variance() {
-  return abs(this->s21->get_setpoint() -
-             this->calc_s21_setpoint(this->target_temperature));
+  return abs(this->s21->get_setpoint() - this->calc_s21_setpoint());
 }
 
 void DaikinS21Climate::save_setpoint(float value, ESPPreferenceObject &pref) {
-  int16_t stored_val = static_cast<int16_t>(value * 10.0);
+  int16_t stored_val = static_cast<int16_t>(value * 10.0F);
   pref.save(&stored_val);
 }
 
 void DaikinS21Climate::save_setpoint(float value) {
   optional<float> prev = this->load_setpoint();
   // Only save if value is diff from what's already saved.
-  if (abs(value - prev.value_or(0.0)) >= SETPOINT_STEP) {
+  if (abs(value - prev.value_or(0.0F)) >= SETPOINT_STEP) {
     switch (this->mode) {
       case climate::CLIMATE_MODE_HEAT_COOL:
         this->save_setpoint(value, this->auto_setpoint_pref);
@@ -165,7 +251,7 @@ optional<float> DaikinS21Climate::load_setpoint(ESPPreferenceObject &pref) {
   if (!pref.load(&stored_val)) {
     return {};
   }
-  return static_cast<float>(stored_val) / 10.0;
+  return static_cast<float>(stored_val) / 10.0F;
 }
 
 optional<float> DaikinS21Climate::load_setpoint() {
@@ -186,127 +272,69 @@ optional<float> DaikinS21Climate::load_setpoint() {
   return loaded;
 }
 
-bool DaikinS21Climate::should_check_setpoint(climate::ClimateMode mode) {
-  bool mode_uses_setpoint = mode == climate::CLIMATE_MODE_HEAT_COOL ||
-                            mode == climate::CLIMATE_MODE_COOL ||
-                            mode == climate::CLIMATE_MODE_HEAT;
-  bool skip_check = false;
-  if (this->skip_setpoint_checks > 0) {
-    this->skip_setpoint_checks--;
-    skip_check = true;
-  }
-  bool min_passed =
-      this->setpoint_interval == 0 || this->last_setpoint_check == 0 ||
-      (millis() - this->last_setpoint_check > (this->setpoint_interval * 1000));
-  return mode_uses_setpoint && !skip_check && min_passed;
+bool DaikinS21Climate::should_check_setpoint() {
+  bool mode_uses_setpoint = (this->mode == climate::CLIMATE_MODE_HEAT_COOL) ||
+                            (this->mode == climate::CLIMATE_MODE_COOL) ||
+                            (this->mode == climate::CLIMATE_MODE_HEAT);
+  bool time_elapsed = (millis() - this->last_setpoint_check_ms) > (this->setpoint_interval_s * 1000);
+  return mode_uses_setpoint && time_elapsed;
 }
 
-void DaikinS21Climate::update() {
-  if (this->use_room_sensor()) {
-    ESP_LOGD(TAG, "Room temp from external sensor: %.1f %s (%.1f °C)",
-             this->room_sensor_->get_state(),
-             this->room_sensor_->get_unit_of_measurement().c_str(),
-             this->room_sensor_degc());
-    ESP_LOGD(TAG, "  Offset: %.1f", this->get_room_temp_offset());
-  }
-  if (this->s21->is_ready()) {
-    this->mode = this->s21->get_climate_mode();
-    this->action = this->s21->get_climate_action();
-    this->set_custom_fan_mode_(daikin_fan_mode_to_string_ref(this->s21->get_fan_mode()).str());
-    this->swing_mode = this->s21->get_swing_mode();
-    this->current_temperature = this->get_effective_current_temperature();
-    this->current_humidity = this->s21->get_humidity();
-
-    if (this->should_check_setpoint(this->mode)) {
-      this->last_setpoint_check = millis();
-      // Target temperature is stored by climate class, and is used to represent
-      // the user's desired temperature. This is distinct from the HVAC unit's
-      // setpoint because we may be using an external sensor. So we only update
-      // the target temperature here if it appears uninitialized.
-      float current_s21_sp = this->s21->get_setpoint();
-      float unexpected_diff = abs(this->expected_s21_setpoint - current_s21_sp);
-      if (this->target_temperature == 0.0 || isnanf(this->target_temperature)) {
-        // Use stored setpoint for mode, or fall back to use s21's setpoint.
-        auto stored = this->load_setpoint();
-        this->target_temperature = stored.value_or(current_s21_sp);
-        this->set_s21_climate();
-      } else if (unexpected_diff >= SETPOINT_STEP) {
-        // User probably set temp via IR remote -- so try to honor their wish by
-        // matching controller's target value to what they sent via remote.
-        ESP_LOGI(TAG, "S21 setpoint changed outside controller");
-        ESP_LOGI(TAG, "  Expected: %.1f", this->expected_s21_setpoint);
-        ESP_LOGI(TAG, "  Found: %.1f", current_s21_sp);
-        this->target_temperature = current_s21_sp;
-        ESP_LOGI(TAG, "  Target temp updated to %.1f", current_s21_sp);
-        this->set_s21_climate();
-      } else if (this->s21_setpoint_variance() >= SETPOINT_STEP) {
-        // Room temperature offset has probably changed, so we need to adjust
-        // the s21 setpoint based on the new difference.
-        this->set_s21_climate();
-        ESP_LOGI(TAG, "S21 setpoint updated to %.1f",
-                 this->expected_s21_setpoint);
-      }
-    }
-
-    this->publish_state();
-  }
-}
-
+/**
+ * Inherited ESPHome climate control call handler.
+ * 
+ * Populates internal state with contained arguments then applies to the unit.
+ *
+ * @param call the call to process
+ */
 void DaikinS21Climate::control(const climate::ClimateCall &call) {
-  bool set_basic = false;
-
   if (call.get_mode().has_value()) {
-    climate::ClimateMode climate_mode = call.get_mode().value();
-    if (this->mode != climate_mode) {
-      this->mode = climate_mode;
-      set_basic = true;
-      if (!call.get_target_temperature().has_value()) {
-        // If call does not include target, then try to use saved target.
-        optional<float> sp = this->load_setpoint();
-        if (sp.has_value()) {
-          this->target_temperature = nearest_step(sp.value());
-        }
+    this->mode = call.get_mode().value();
+    if (!call.get_target_temperature().has_value()) {
+      // If call does not include target, then try to use saved target.
+      optional<float> sp = this->load_setpoint();
+      if (sp.has_value()) {
+        this->target_temperature = nearest_step(sp.value());
       }
     }
   }
   if (call.get_target_temperature().has_value()) {
-    this->target_temperature =
-        nearest_step(call.get_target_temperature().value());
-    set_basic = true;
+    this->target_temperature = nearest_step(call.get_target_temperature().value());
   }
   if (call.get_custom_fan_mode().has_value()) {
     this->custom_fan_mode = call.get_custom_fan_mode().value();
-    set_basic = true;
   }
-
-  if (set_basic) {
-    this->set_s21_climate();
-  }
-
   if (call.get_swing_mode().has_value()) {
-    this->s21->set_swing_settings(call.get_swing_mode().value());
+    this->swing_mode = call.get_swing_mode().value();
   }
-
-  this->update();
+  this->set_s21_climate();
 }
 
+/**
+ * Apply ESPHome Climate state to the unit.
+ *
+ * Converts to internal settings format and forwards to DaikinS21 component to apply.
+ */
 void DaikinS21Climate::set_s21_climate() {
-  this->expected_s21_setpoint = this->calc_s21_setpoint(this->target_temperature);
-  ESP_LOGI(TAG, "Controlling S21 climate:");
-  ESP_LOGI(TAG, "  Mode: %s", LOG_STR_ARG(climate::climate_mode_to_string(this->mode)));
-  ESP_LOGI(TAG, "  Setpoint: %.1f (s21: %.1f)", this->target_temperature,
-          this->expected_s21_setpoint);
-  ESP_LOGI(TAG, "  Fan: %s", this->custom_fan_mode.value().c_str());
+  // Set and command new settings
+  this->commanded.mode = this->mode;
+  this->commanded.setpoint = this->calc_s21_setpoint();
+  this->commanded.fan = string_to_daikin_fan_mode(this->custom_fan_mode.value());
+  this->commanded.swing = this->swing_mode;
+  this->s21->set_climate_settings(this->commanded);
 
-  this->s21->set_climate_settings(
-      this->mode,
-      this->expected_s21_setpoint,
-      string_to_daikin_fan_mode(this->custom_fan_mode.value()));
-  // HVAC unit seems to take a few seconds to begin reporting mode and setpoint
-  // changes back to the controller, so when modifying settings, setpoint checks
-  // are skipped to avoid unexpected setpoint updates, especially when changing
-  // modes.
-  this->skip_setpoint_checks = 2;
+  ESP_LOGI(TAG, "Controlling S21 climate:");
+  ESP_LOGI(TAG, "  Mode: %s", LOG_STR_ARG(climate::climate_mode_to_string(this->commanded.mode)));
+  ESP_LOGI(TAG, "  Setpoint: %.1f (s21: %.1f)", this->target_temperature, this->commanded.setpoint.f_degc());
+  ESP_LOGI(TAG, "  Fan: %s", LOG_STR_ARG(daikin_fan_mode_to_string_ref(this->commanded.fan).c_str()));
+  ESP_LOGI(TAG, "  Swing: %s", LOG_STR_ARG(climate::climate_swing_mode_to_string(this->commanded.swing)));
+
+  // HVAC unit takes a few seconds to begin reporting settings changes back to
+  // the controller, so when modifying don't publish current state until it
+  // takes effect or is given enough time to take effect or we get a jumpy UI
+  // in Home Assistant as stale state is published over the commanded state
+  // followed by the active state.
+  this->command_timeout_end_ms = millis() + state_publication_timeout_ms;
   this->save_setpoint(this->target_temperature);
 }
 

--- a/components/daikin_s21/climate/daikin_s21_climate.h
+++ b/components/daikin_s21/climate/daikin_s21_climate.h
@@ -1,62 +1,61 @@
 #pragma once
 
-#include <map>
 #include "esphome/components/climate/climate.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/uart/uart.h"
 #include "esphome/core/component.h"
 #include "esphome/core/preferences.h"
+#include "../daikin_s21_fan_modes.h"
 #include "../s21.h"
 
 namespace esphome {
 namespace daikin_s21 {
 
 class DaikinS21Climate : public climate::Climate,
-                         public PollingComponent,
+                         public Component,
                          public DaikinS21Client {
  public:
   void setup() override;
-  void update() override;
+  void loop() override;
   void dump_config() override;
   void control(const climate::ClimateCall &call) override;
 
   void set_room_sensor(sensor::Sensor *sensor) { this->room_sensor_ = sensor; }
-  void set_setpoint_interval(uint16_t seconds) {
-    this->setpoint_interval = seconds;
-  };
-  float get_s21_setpoint() { return this->s21->get_setpoint(); }
-  float get_room_temp_offset();
-
-  bool should_check_setpoint(climate::ClimateMode mode);
-
+  void set_setpoint_interval(uint16_t seconds) { this->setpoint_interval_s = seconds; };
   void set_supported_modes_override(std::set<climate::ClimateMode> modes) { this->supported_modes_override_ = std::move(modes); }
   void set_supports_current_humidity(bool supports_current_humidity) { this->supports_current_humidity_ = supports_current_humidity; }
 
  protected:
+  static constexpr uint32_t state_publication_timeout_ms{8 * 1000};
+
   climate::ClimateTraits traits() override;
   optional<std::set<climate::ClimateMode>> supported_modes_override_{};
   bool supports_current_humidity_{false};
 
   sensor::Sensor *room_sensor_{nullptr};
-  float expected_s21_setpoint;
-  uint8_t skip_setpoint_checks = 0;
-  uint16_t setpoint_interval = 0;
-  uint32_t last_setpoint_check = 0;
+  uint16_t setpoint_interval_s{0};
+  uint32_t last_setpoint_check_ms{millis()};
+
+  uint32_t command_timeout_end_ms{millis()}; // publish current state immediately on startup
+  DaikinSettings commanded{};
 
   ESPPreferenceObject auto_setpoint_pref;
   ESPPreferenceObject cool_setpoint_pref;
   ESPPreferenceObject heat_setpoint_pref;
 
+  void set_custom_fan_mode(DaikinFanMode mode);
   bool use_room_sensor();
   bool room_sensor_unit_is_valid();
   float room_sensor_degc();
   float get_effective_current_temperature();
-  float calc_s21_setpoint(float target);
+  float get_room_temp_offset();
+  float calc_s21_setpoint();
   float s21_setpoint_variance();
   void save_setpoint(float value, ESPPreferenceObject &pref);
   void save_setpoint(float value);
   optional<float> load_setpoint(ESPPreferenceObject &pref);
   optional<float> load_setpoint();
+  bool should_check_setpoint();
   void set_s21_climate();
 };
 

--- a/components/daikin_s21/s21.h
+++ b/components/daikin_s21/s21.h
@@ -13,8 +13,8 @@ namespace daikin_s21 {
 
 class DaikinSerial {
 public:
-  static constexpr uint32_t S21_MAX_COMMAND_SIZE = 4;
-  static constexpr uint32_t S21_PAYLOAD_SIZE = 4;
+  static constexpr uint32_t S21_MAX_COMMAND_SIZE{4};
+  static constexpr uint32_t S21_PAYLOAD_SIZE{4};
 
   enum class Result : uint8_t {
     Idle,
@@ -32,8 +32,8 @@ public:
   Result send_frame(const char *cmd, const std::array<char, S21_PAYLOAD_SIZE> *payload = nullptr);
   void flush_input();
   
-  std::vector<uint8_t> response = {};
-  bool debug = false;
+  std::vector<uint8_t> response{};
+  bool debug{false};
 
 private:
   Result handle_rx(uint8_t byte);
@@ -51,18 +51,44 @@ private:
 
   uart::UARTComponent *tx_uart{nullptr};
   uart::UARTComponent *rx_uart{nullptr};
-  CommState comm_state = CommState::Idle;
-  uint32_t last_event_time_ms = 0;
+  CommState comm_state{CommState::Idle};
+  uint32_t last_event_time_ms{0};
 };
 
+/**
+ * Class representing a temperature in degrees C scaled by 10, the most granular internal temperature measurement format
+ */
+struct DaikinC10 {
+  template <typename T, typename std::enable_if<std::is_floating_point<T>::value, bool>::type = true>
+  constexpr DaikinC10(const T valf) : value((static_cast<int16_t>(valf * 10 * 2) + 1) / 2) {} // round to nearest 0.1C
+
+  template <typename T, typename std::enable_if<std::is_integral<T>::value, bool>::type = true>
+  constexpr DaikinC10(const T vali) : value(vali) {}
+
+  explicit constexpr operator float() const { return value / 10.0F; }
+  explicit constexpr operator int16_t() const { return value; }
+  constexpr float f_degc() const { return static_cast<float>(*this); }
+  constexpr float f_degf() const { return static_cast<float>(*this) * 1.8F + 32.0F; }
+
+  constexpr bool operator==(const DaikinC10 &other) const { return this->value == other.value; }
+  
+private:
+  int16_t value;
+};
 
 struct DaikinSettings {
-  climate::ClimateMode mode = climate::CLIMATE_MODE_OFF;
-  int16_t setpoint = 23 * 10;
-  DaikinFanMode fan = DaikinFanMode::Auto;
-  climate::ClimateSwingMode swing = climate::CLIMATE_SWING_OFF;
-};
+  climate::ClimateMode mode{climate::CLIMATE_MODE_OFF};
+  DaikinC10 setpoint{23};
+  DaikinFanMode fan{DaikinFanMode::Auto};
+  climate::ClimateSwingMode swing{climate::CLIMATE_SWING_OFF};
 
+  constexpr bool operator==(const DaikinSettings &other) const {
+    return (this->mode == other.mode) &&
+           (this->setpoint == other.setpoint) &&
+           (this->fan == other.fan) &&
+           (this->swing == other.swing);
+  }
+};
 
 class DaikinS21 : public PollingComponent {
  public:
@@ -75,24 +101,26 @@ class DaikinS21 : public PollingComponent {
   void set_debug_comms(bool set) { this->serial.debug = set; }
   void set_debug_protocol(bool set) { this->debug_protocol = set; }
 
-  // external command actions
-  void set_climate_settings(climate::ClimateMode mode, float setpoint, DaikinFanMode fan_mode);
-  void set_swing_settings(climate::ClimateSwingMode swing);
+  // external command action
+  void set_climate_settings(const DaikinSettings &settings);
+  const DaikinSettings& get_climate_settings() { return this->active; };
 
   bool is_ready() { return this->ready.all(); }
   climate::ClimateMode get_climate_mode() { return this->active.mode; }
   climate::ClimateAction get_climate_action();
   DaikinFanMode get_fan_mode() { return this->active.fan; }
   climate::ClimateSwingMode get_swing_mode() { return this->active.swing; }
-  float get_setpoint() { return this->active.setpoint / 10.0F; }
-  float get_temp_inside() { return this->temp_inside / 10.0; }
-  float get_temp_outside() { return this->temp_outside / 10.0; }
-  float get_temp_coil() { return this->temp_coil / 10.0; }
+  auto get_setpoint() { return this->active.setpoint.f_degc(); }
+  auto get_temp_inside() { return this->temp_inside.f_degc(); }
+  auto get_temp_outside() { return this->temp_outside.f_degc(); }
+  auto get_temp_coil() { return this->temp_coil.f_degc(); }
   auto get_fan_rpm() { return this->fan_rpm; }
   auto get_swing_vertical_angle() { return this->swing_vertical_angle; }
   auto get_compressor_frequency() { return this->compressor_hz; }
   auto get_humidity() { return this->humidity; }
   auto get_demand() { return this->demand; }
+
+  bool climate_updated = false;
 
  protected:
   DaikinSerial serial;
@@ -109,49 +137,47 @@ class DaikinS21 : public PollingComponent {
     ReadyBasic,
     ReadyCount, // just for bitset sizing
   };
-  std::bitset<ReadyCount> ready = {};
+  std::bitset<ReadyCount> ready{};
 
   // communication state
   bool is_query_active(const char * query_str);
   bool prune_query(const char * query_str);
-  std::vector<const char *> queries = {};
+  std::vector<const char *> queries{};
   std::vector<const char *>::iterator current_query;
-  const char *tx_command = "";  // used when matching responses - value must have persistent lifetime across serial state machine runs
-  bool refresh_state = false;
-  bool debug_protocol = false;
-  std::unordered_map<std::string, std::vector<uint8_t>> val_cache;  // debugging
+  const char *tx_command{""};  // used when matching responses - value must have persistent lifetime across serial state machine runs
+  bool debug_protocol{false};
+  std::unordered_map<std::string, std::vector<uint8_t>> val_cache{};  // debugging
 
   // settings
-  DaikinSettings active = {};
-  DaikinSettings pending = {};
-  bool activate_climate = false;
-  bool activate_swing_mode = false;
+  DaikinSettings active{};
+  DaikinSettings pending{ .mode = climate::CLIMATE_MODE_AUTO }; // unsupported sentinel value, see set_climate_settings
+  bool activate_climate{false};
+  bool activate_swing_mode{false};
 
   // current values
   climate::ClimateAction climate_action = climate::CLIMATE_ACTION_OFF;
-  int16_t temp_inside = 0;
-  int16_t temp_target = 0;
-  int16_t temp_outside = 0;
-  int16_t temp_coil = 0;
-  uint16_t fan_rpm = 0;
-  int16_t swing_vertical_angle = 0;
-  uint8_t compressor_hz = 0;
-  uint8_t humidity = 50;
-  uint8_t demand = 0;
+  DaikinC10 temp_inside{0};
+  DaikinC10 temp_target{0};
+  DaikinC10 temp_outside{0};
+  DaikinC10 temp_coil{0};
+  uint16_t fan_rpm{0};
+  int16_t swing_vertical_angle{0};
+  uint8_t compressor_hz{0};
+  uint8_t humidity{50};
+  uint8_t demand{0};
 
   // protocol support
   bool determine_protocol_version();
-  uint8_t G8[4] = {};
-  uint16_t GY00 = 0;
+  uint8_t G8[4]{};
+  uint16_t GY00{0};
   struct ProtocolVersion {
-    uint8_t major = std::numeric_limits<uint8_t>::max();
-    uint8_t minor = std::numeric_limits<uint8_t>::max();
-  };
-  ProtocolVersion protocol_version = {};
-  char G2_model_info = 0;
-  bool support_swing = false;
-  bool support_horizontal_swing = false;
-  bool support_humidity = false;
+    uint8_t major{std::numeric_limits<uint8_t>::max()};
+    uint8_t minor{std::numeric_limits<uint8_t>::max()};
+  } protocol_version{};
+  char G2_model_info{0};
+  bool support_swing{false};
+  bool support_horizontal_swing{false};
+  bool support_humidity{false};
 };
 
 class DaikinS21Client {


### PR DESCRIPTION
Unlock DaikinS21 polling loop, detect updates as soon as possible. Follow ESPHome convention and consolidate S21 command interface to match ClimateCall's range of parameters (add swing to it, let it deal with issuing multiple commands to the unit under the hood, if necessary). Cuts down on communication bandwidth with the unit. Better synchronize multiple commands to the unit, don't lose a very sudden followup command while processing the first.

Unlock DaikinS21Climate polling loop, detect updates from DaikinS21 as soon as possible. Since it's much more responsive, add a short timeout to prevent publishing stale climate state while the device is processing a control command. This prevents Home Assistant UI from being jumpy when configuring, like it was in previous revisions.

Only publish climate updates when the state changes. This includes when Home Assistant makes a ClimateCall and it's applied successfully to the unit. Cuts down on log spam and network traffic. Better synchronize controller state with unit on startup, don't lose the first command to change swing settings (minor bug).

Also:
- Introduce abstracted DaikinC10 datatype for temperature representation.
- Use existing internal structure and type definitions in Climate module.
- Reduce some unnecessary parameter passing in member functions.
- Avoid using optional variables without checking in debugging statements.
- Add a bit more code documentation

Resolves #33