### PR TITLE
Climate refactor fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,13 @@ sensor:
     humidity:
       name: Humidity
     demand:
-      name: Demand
-      max_value: 9  # optional maximum raw value. determines reported percentage.
+      name: Demand  # 0-15 demand units, use filter to map to %
+      filters:
+        - calibrate_linear:
+           method: exact  # default of least_squares results in -0% when 0
+           datapoints:
+             - 0 -> 0
+             - 15 -> 100
   - platform: homeassistant
     id: room_temp
     entity_id: sensor.office_temperature

--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -308,6 +308,7 @@ void DaikinS21Climate::control(const climate::ClimateCall &call) {
     this->swing_mode = call.get_swing_mode().value();
   }
   this->set_s21_climate();
+  this->publish_state();
 }
 
 /**

--- a/components/daikin_s21/sensor/__init__.py
+++ b/components/daikin_s21/sensor/__init__.py
@@ -8,7 +8,6 @@ from esphome.components import sensor
 from esphome.const import (
     CONF_HUMIDITY,
     CONF_ID,
-    CONF_MAX_VALUE,
     UNIT_CELSIUS,
     UNIT_DEGREES,
     UNIT_HERTZ,
@@ -100,11 +99,6 @@ CONFIG_SCHEMA = (
                 icon="mdi:thermometer-chevron-up",
                 accuracy_decimals=0,
                 state_class=STATE_CLASS_MEASUREMENT,
-            )
-            .extend(
-                {
-                    cv.Optional(CONF_MAX_VALUE, default=15): cv.int_,
-                }
             ),
         }
     )
@@ -152,5 +146,3 @@ async def to_code(config):
     if CONF_DEMAND in config:
         sens = await sensor.new_sensor(config[CONF_DEMAND])
         cg.add(var.set_demand_sensor(sens))
-        if CONF_MAX_VALUE in config[CONF_DEMAND]:
-            cg.add(var.set_demand_max(config[CONF_DEMAND][CONF_MAX_VALUE]))

--- a/components/daikin_s21/sensor/daikin_s21_sensor.cpp
+++ b/components/daikin_s21/sensor/daikin_s21_sensor.cpp
@@ -30,7 +30,7 @@ void DaikinS21Sensor::update() {
     this->humidity_sensor_->publish_state(this->s21->get_humidity());
   }
   if (this->demand_sensor_ != nullptr) {
-    this->demand_sensor_->publish_state(100.0F * this->s21->get_demand() / this->demand_max);
+    this->demand_sensor_->publish_state(this->s21->get_demand());
   }
 }
 

--- a/components/daikin_s21/sensor/daikin_s21_sensor.h
+++ b/components/daikin_s21/sensor/daikin_s21_sensor.h
@@ -35,9 +35,6 @@ class DaikinS21Sensor : public PollingComponent, public DaikinS21Client {
   void set_demand_sensor(sensor::Sensor *sensor) {
     this->demand_sensor_ = sensor;
   }
-  void set_demand_max(uint8_t demand_max) {
-    this->demand_max = demand_max;
-  }
 
  protected:
   sensor::Sensor *temp_inside_sensor_{nullptr};
@@ -48,7 +45,6 @@ class DaikinS21Sensor : public PollingComponent, public DaikinS21Client {
   sensor::Sensor *compressor_frequency_sensor_{nullptr};
   sensor::Sensor *humidity_sensor_{nullptr};
   sensor::Sensor *demand_sensor_{nullptr};
-  uint8_t demand_max = 15;
 };
 
 }  // namespace daikin_s21


### PR DESCRIPTION
Publish state as soon as it's received. I was wrong about Home Assistant handling of UI versus component state. Previous code relied on incidental changes in state (like current temperature or action) to publish an update to HA. When there was no change in state the UI would lag until the command took effect in the unit and that change was published. You could see this when switching between HEAT_COOL and HEAT with setpoints resulting in the same action. Now we optimistically report the desired state and publish a correction later if it doesn't take.

Remove max_demand setting from demand sensor and provide a configuration example to do mapping to percent with a standard filter.