### PR TITLE
Add preliminary binary sensor implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Climate:
 - Swing modes horizontal, vertical, and both.
 - Optional humidity reporting.
 
-Sensors:
+Sensor:
 * Inside temperature (usually measured at indoor air handler return)
 * Outside temperature (outside exchanger)
 * Coil temperature (indoor air handler's coil)
@@ -30,6 +30,9 @@ Sensors:
 * Compressor frequency (outside exchanger)
 * Humidity (not supported on all units, will report a consistent 50% if not present)
 * Unit demand from outside exchanger
+
+Binary Sensor:
+* New, extracted from the unit and system state bitfields. Still need to observe to see how valuable these are.
 
 On multihead systems the outdoor values will be the same (accounting for sampling jitter). It
 could be cleaner to only configure these sensors on your "primary" ESPhome device. ESPHome is
@@ -78,6 +81,9 @@ on having pins inverted differently.
 ## Configuration Example
 
 ```yaml
+esphome:
+  min_version: "2025.7"
+
 logger:
   baud_rate: 0  # Disable UART logger if using UART0 (pins 1,3)
 
@@ -136,16 +142,25 @@ sensor:
       name: Humidity
     demand:
       name: Demand  # 0-15 demand units, use filter to map to %
-      filters:
-        - calibrate_linear:
-           method: exact  # default of least_squares results in -0% when input 0
-           datapoints:
-             - 0 -> 0
-             - 15 -> 100
+      filters:  
+        - multiply: !lambda return 100.0F / 15.0F;
   - platform: homeassistant
     id: room_temp
     entity_id: sensor.office_temperature
     unit_of_measurement: °F
+
+binary_sensor:
+  - platform: daikin_s21
+    powerful:
+      name: Powerful
+    defrost:
+      name: Defrost
+    valve:
+      name: Valve
+    short_cycle:
+      name: Short Cycle
+    system_defrost:
+      name: System Defrost
 ```
 
 Here is an example of how daikin_s21 can be used with one inverted UART pin:

--- a/components/daikin_s21/binary_sensor/__init__.py
+++ b/components/daikin_s21/binary_sensor/__init__.py
@@ -1,0 +1,83 @@
+"""
+Binary sensor component for daikin_s21.
+"""
+
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import binary_sensor
+from esphome.const import (
+    CONF_ID,
+    DEVICE_CLASS_COLD,
+    DEVICE_CLASS_LOCK,
+    DEVICE_CLASS_OPENING,
+    DEVICE_CLASS_POWER,
+    DEVICE_CLASS_RUNNING,
+)
+
+from .. import (
+    daikin_s21_ns,
+    CONF_S21_ID,
+    S21_CLIENT_SCHEMA,
+    DaikinS21Client,
+)
+
+DaikinS21BinarySensor = daikin_s21_ns.class_(
+    "DaikinS21BinarySensor", cg.PollingComponent, DaikinS21Client
+)
+
+CONF_S21_ID = "s21_id"
+CONF_POWERFUL = "powerful"
+CONF_DEFROST = "defrost"
+CONF_ACTIVE = "active"
+CONF_VALVE = "valve"
+CONF_SHORT_CYCLE = "short_cycle"
+CONF_SYSTEM_DEFROST = "system_defrost"
+
+CONFIG_SCHEMA = (
+    cv.COMPONENT_SCHEMA.extend(
+        {
+            cv.GenerateID(): cv.declare_id(DaikinS21BinarySensor),
+            cv.Optional(CONF_POWERFUL): binary_sensor.binary_sensor_schema(
+                device_class=DEVICE_CLASS_POWER,
+            ),
+            cv.Optional(CONF_DEFROST): binary_sensor.binary_sensor_schema(
+                device_class=DEVICE_CLASS_COLD,
+            ),
+            cv.Optional(CONF_ACTIVE): binary_sensor.binary_sensor_schema(
+                device_class=DEVICE_CLASS_RUNNING,
+            ),
+            cv.Optional(CONF_VALVE): binary_sensor.binary_sensor_schema(
+                device_class=DEVICE_CLASS_OPENING,
+            ),
+            cv.Optional(CONF_SHORT_CYCLE): binary_sensor.binary_sensor_schema(
+                device_class=DEVICE_CLASS_LOCK,
+            ),
+            cv.Optional(CONF_SYSTEM_DEFROST): binary_sensor.binary_sensor_schema(
+                device_class=DEVICE_CLASS_COLD,
+            ),
+        }
+    )
+    .extend(S21_CLIENT_SCHEMA)
+    .extend(cv.polling_component_schema("10s"))
+)
+
+async def to_code(config):
+    """Generate main.cpp code"""
+
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    s21_var = await cg.get_variable(config[CONF_S21_ID])
+    cg.add(var.set_s21(s21_var))
+    
+    binary_sensors = (
+        (CONF_POWERFUL, var.set_powerful_sensor),
+        (CONF_DEFROST, var.set_defrost_sensor),
+        (CONF_ACTIVE, var.set_active_sensor),
+        (CONF_VALVE, var.set_valve_sensor),
+        (CONF_SHORT_CYCLE, var.set_short_cycle_sensor),
+        (CONF_SYSTEM_DEFROST, var.set_system_defrost_sensor),
+    )
+    for key, func in binary_sensors:
+        if key in config:
+            sens = await binary_sensor.new_binary_sensor(config[key])
+            cg.add(func(sens))

--- a/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.cpp
+++ b/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.cpp
@@ -1,0 +1,45 @@
+#include "daikin_s21_binary_sensor.h"
+
+namespace esphome {
+namespace daikin_s21 {
+
+static const char *const TAG = "daikin_s21.binary_sensor";
+
+void DaikinS21BinarySensor::update() {
+  if (!this->s21->is_ready())
+    return;
+
+  const auto unit_state = s21->unit_state;
+  const auto system_state = s21->system_state;
+  if (this->powerful_sensor_ != nullptr) {
+    this->powerful_sensor_->publish_state(unit_state & 0x1);
+  }
+  if (this->defrost_sensor_ != nullptr) {
+    this->defrost_sensor_->publish_state(unit_state & 0x2);
+  }
+  if (this->active_sensor_ != nullptr) {
+    this->active_sensor_->publish_state(unit_state & 0x4);  // unit
+  }
+  if (this->valve_sensor_ != nullptr) {
+    this->valve_sensor_->publish_state(system_state & 0x04);  // system
+  }
+  if (this->short_cycle_sensor_ != nullptr) {
+    this->short_cycle_sensor_->publish_state((system_state & 0x01) == 0x00);  // invert for ESPHome logic
+  }
+  if (this->system_defrost_sensor_ != nullptr) {
+    this->system_defrost_sensor_->publish_state(system_state & 0x08);
+  }
+}
+
+void DaikinS21BinarySensor::dump_config() {
+  ESP_LOGCONFIG(TAG, "Daikin S21 Binary Sensor:");
+  LOG_BINARY_SENSOR("  ", "Powerful", this->powerful_sensor_);
+  LOG_BINARY_SENSOR("  ", "Defrost", this->defrost_sensor_);
+  LOG_BINARY_SENSOR("  ", "Active", this->active_sensor_);
+  LOG_BINARY_SENSOR("  ", "Valve", this->valve_sensor_);
+  LOG_BINARY_SENSOR("  ", "Short Cycle", this->short_cycle_sensor_);
+  LOG_BINARY_SENSOR("  ", "System Defrost", this->system_defrost_sensor_);
+}
+
+}  // namespace daikin_s21
+}  // namespace esphome

--- a/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.h
+++ b/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#include "../s21.h"
+
+namespace esphome {
+namespace daikin_s21 {
+
+class DaikinS21BinarySensor : public PollingComponent, public DaikinS21Client {
+ public:
+  void update() override;
+  void dump_config() override;
+
+  void set_powerful_sensor(binary_sensor::BinarySensor *sensor) {
+    this->powerful_sensor_ = sensor;
+  }
+  void set_defrost_sensor(binary_sensor::BinarySensor *sensor) {
+    this->defrost_sensor_ = sensor;
+  }
+  void set_active_sensor(binary_sensor::BinarySensor *sensor) {
+    this->active_sensor_ = sensor;
+  }
+  void set_valve_sensor(binary_sensor::BinarySensor *sensor) {
+    this->valve_sensor_ = sensor;
+  }
+  void set_short_cycle_sensor(binary_sensor::BinarySensor *sensor) {
+    this->short_cycle_sensor_ = sensor;
+  }
+  void set_system_defrost_sensor(binary_sensor::BinarySensor *sensor) {
+    this->system_defrost_sensor_ = sensor;
+  }
+
+ protected:
+  binary_sensor::BinarySensor *powerful_sensor_{nullptr};
+  binary_sensor::BinarySensor *defrost_sensor_{nullptr};
+  binary_sensor::BinarySensor *active_sensor_{nullptr};
+  binary_sensor::BinarySensor *valve_sensor_{nullptr};
+  binary_sensor::BinarySensor *short_cycle_sensor_{nullptr};
+  binary_sensor::BinarySensor *system_defrost_sensor_{nullptr};
+};
+
+}  // namespace daikin_s21
+}  // namespace esphome

--- a/components/daikin_s21/s21.h
+++ b/components/daikin_s21/s21.h
@@ -160,11 +160,15 @@ class DaikinS21 : public PollingComponent {
   bool is_query_active(const char * query_str);
   bool prune_query(const char * query_str);
   std::vector<const char *> queries{};
-  std::vector<const char *>::iterator current_query;
+  std::vector<const char *>::iterator current_query{};
   const char *tx_command{""};  // used when matching responses - value must have persistent lifetime across serial state machine runs
+  
+  // debugging support
   bool debug_protocol{false};
-  std::unordered_map<std::string, std::vector<uint8_t>> val_cache{};  // debugging
-  std::vector<const char *> nak_queries{};   // debugging
+  std::unordered_map<std::string, std::vector<uint8_t>> val_cache{};
+  std::vector<const char *> nak_queries{};
+  uint32_t cycle_time_start_ms{0};
+  uint32_t cycle_time_ms{0};
 
   // settings
   DaikinSettings active{};

--- a/components/daikin_s21/sensor/__init__.py
+++ b/components/daikin_s21/sensor/__init__.py
@@ -13,8 +13,6 @@ from esphome.const import (
     UNIT_PERCENT,
     UNIT_REVOLUTIONS_PER_MINUTE,
     ICON_FAN,
-    ICON_THERMOMETER,
-    ICON_WATER_PERCENT,
     DEVICE_CLASS_FREQUENCY,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_TEMPERATURE,
@@ -48,21 +46,18 @@ CONFIG_SCHEMA = (
             cv.GenerateID(): cv.declare_id(DaikinS21Sensor),
             cv.Optional(CONF_INSIDE_TEMP): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
-                icon=ICON_THERMOMETER,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_OUTSIDE_TEMP): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
-                icon=ICON_THERMOMETER,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_COIL_TEMP): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
-                icon=ICON_THERMOMETER,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
@@ -89,7 +84,6 @@ CONFIG_SCHEMA = (
             ),
             cv.Optional(CONF_HUMIDITY): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PERCENT,
-                icon=ICON_WATER_PERCENT,
                 accuracy_decimals=0,
                 device_class=DEVICE_CLASS_HUMIDITY,
                 state_class=STATE_CLASS_MEASUREMENT,
@@ -115,34 +109,17 @@ async def to_code(config):
     s21_var = await cg.get_variable(config[CONF_S21_ID])
     cg.add(var.set_s21(s21_var))
 
-    if CONF_INSIDE_TEMP in config:
-        sens = await sensor.new_sensor(config[CONF_INSIDE_TEMP])
-        cg.add(var.set_temp_inside_sensor(sens))
-
-    if CONF_OUTSIDE_TEMP in config:
-        sens = await sensor.new_sensor(config[CONF_OUTSIDE_TEMP])
-        cg.add(var.set_temp_outside_sensor(sens))
-
-    if CONF_COIL_TEMP in config:
-        sens = await sensor.new_sensor(config[CONF_COIL_TEMP])
-        cg.add(var.set_temp_coil_sensor(sens))
-
-    if CONF_FAN_SPEED in config:
-        sens = await sensor.new_sensor(config[CONF_FAN_SPEED])
-        cg.add(var.set_fan_speed_sensor(sens))
-
-    if CONF_SWING_VERTICAL_ANGLE in config:
-        sens = await sensor.new_sensor(config[CONF_SWING_VERTICAL_ANGLE])
-        cg.add(var.set_swing_vertical_angle_sensor(sens))
-
-    if CONF_COMPRESSOR_FREQUENCY in config:
-        sens = await sensor.new_sensor(config[CONF_COMPRESSOR_FREQUENCY])
-        cg.add(var.set_compressor_frequency_sensor(sens))
-    
-    if CONF_HUMIDITY in config:
-        sens = await sensor.new_sensor(config[CONF_HUMIDITY])
-        cg.add(var.set_humidity_sensor(sens))
-
-    if CONF_DEMAND in config:
-        sens = await sensor.new_sensor(config[CONF_DEMAND])
-        cg.add(var.set_demand_sensor(sens))
+    sensors = (
+        (CONF_INSIDE_TEMP, var.set_temp_inside_sensor),
+        (CONF_OUTSIDE_TEMP, var.set_temp_outside_sensor),
+        (CONF_COIL_TEMP, var.set_temp_coil_sensor),
+        (CONF_FAN_SPEED, var.set_fan_speed_sensor),
+        (CONF_SWING_VERTICAL_ANGLE, var.set_swing_vertical_angle_sensor),
+        (CONF_COMPRESSOR_FREQUENCY, var.set_compressor_frequency_sensor),
+        (CONF_HUMIDITY, var.set_humidity_sensor),
+        (CONF_DEMAND, var.set_demand_sensor),
+    )
+    for key, func in sensors:
+        if key in config:
+            sens = await sensor.new_sensor(config[key])
+            cg.add(func(sens))


### PR DESCRIPTION
- Extract system and unit state bitfields and turn into binary sensors
- Update Demand filter example
- Add a query cycle time to debugging output. 3.1s for me. Compact output a bit.
- Consolidate some repetitive python code
- Add ESPHome 2025.7 minimum to example configuration. Necessary for C++20 features to come.

Resolves #19 