### PR TITLE
Cleanup and Arduino framework mitigation

### DIFF
--- a/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.h
+++ b/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.h
@@ -6,7 +6,8 @@
 namespace esphome {
 namespace daikin_s21 {
 
-class DaikinS21BinarySensor : public PollingComponent, public DaikinS21Client {
+class DaikinS21BinarySensor : public PollingComponent,
+                              public DaikinS21Client {
  public:
   void update() override;
   void dump_config() override;

--- a/components/daikin_s21/climate/__init__.py
+++ b/components/daikin_s21/climate/__init__.py
@@ -5,9 +5,10 @@ Daikin S21 Mini-Split ESPHome component config validation & code generation.
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import climate, sensor
-from esphome.components.climate import ClimateMode
+from esphome.components.climate import ClimateMode, ClimatePreset
 from esphome.const import (
     CONF_SUPPORTED_MODES,
+    CONF_SUPPORTED_PRESETS,
 )
 from .. import (
     daikin_s21_ns,
@@ -33,15 +34,19 @@ SUPPORTED_CLIMATE_MODES_OPTIONS = {
     "DRY": ClimateMode.CLIMATE_MODE_DRY,
 }
 
+SUPPORTED_CLIMATE_PRESETS_OPTIONS = {
+    "ECO": ClimatePreset.CLIMATE_PRESET_ECO,
+    "BOOST": ClimatePreset.CLIMATE_PRESET_BOOST,
+}
+
 CONFIG_SCHEMA = cv.All(
     climate.climate_schema(DaikinS21Climate)
     .extend(
         {
             cv.Optional(CONF_ROOM_TEMPERATURE_SENSOR): cv.use_id(sensor.Sensor),
             cv.Optional(CONF_SETPOINT_INTERVAL, default="300s"): cv.positive_time_period_seconds,
-            cv.Optional(CONF_SUPPORTED_MODES): cv.ensure_list(
-                cv.enum(SUPPORTED_CLIMATE_MODES_OPTIONS, upper=True)
-            ),
+            cv.Optional(CONF_SUPPORTED_MODES): cv.ensure_list(cv.enum(SUPPORTED_CLIMATE_MODES_OPTIONS, upper=True)),
+            cv.Optional(CONF_SUPPORTED_PRESETS): cv.ensure_list(cv.enum(SUPPORTED_CLIMATE_PRESETS_OPTIONS, upper=True)),
             cv.Optional(CONF_SUPPORTS_HUMIDITY): cv.boolean,
         }
     )
@@ -63,6 +68,9 @@ async def to_code(config):
 
     if CONF_SUPPORTED_MODES in config:
         cg.add(var.set_supported_modes_override(config[CONF_SUPPORTED_MODES]))
+
+    if CONF_SUPPORTED_PRESETS in config:
+        cg.add(var.set_supported_presets_override(config[CONF_SUPPORTED_PRESETS]))
     
     if CONF_SUPPORTS_HUMIDITY in config:
         cg.add(var.set_supports_current_humidity(config[CONF_SUPPORTS_HUMIDITY]))

--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -161,6 +161,10 @@ climate::ClimateTraits DaikinS21Climate::traits() {
     traits.add_supported_mode(climate::CLIMATE_MODE_OFF);   // Always available
     traits.add_supported_mode(climate::CLIMATE_MODE_HEAT_COOL);  // Always available
   }
+  if (this->supported_presets_override_.has_value()) {
+    traits.set_supported_presets(this->supported_presets_override_.value());
+    traits.add_supported_preset(climate::CLIMATE_PRESET_NONE);
+  }
   return traits;
 }
 
@@ -306,6 +310,9 @@ void DaikinS21Climate::control(const climate::ClimateCall &call) {
   }
   if (call.get_custom_fan_mode().has_value()) {
     this->custom_fan_mode = call.get_custom_fan_mode().value();
+  }
+  if (call.get_preset().has_value()) {
+    this->preset = call.get_preset().value();
   }
   this->set_s21_climate();
   this->publish_state();

--- a/components/daikin_s21/climate/daikin_s21_climate.h
+++ b/components/daikin_s21/climate/daikin_s21_climate.h
@@ -23,6 +23,7 @@ class DaikinS21Climate : public climate::Climate,
   void set_room_sensor(sensor::Sensor *sensor) { this->room_sensor_ = sensor; }
   void set_setpoint_interval(uint16_t seconds) { this->setpoint_interval_s = seconds; };
   void set_supported_modes_override(std::set<climate::ClimateMode> modes) { this->supported_modes_override_ = std::move(modes); }
+  void set_supported_presets_override(std::set<climate::ClimatePreset> presets) { this->supported_presets_override_ = std::move(presets); }
   void set_supports_current_humidity(bool supports_current_humidity) { this->supports_current_humidity_ = supports_current_humidity; }
 
  protected:
@@ -30,6 +31,7 @@ class DaikinS21Climate : public climate::Climate,
 
   climate::ClimateTraits traits() override;
   optional<std::set<climate::ClimateMode>> supported_modes_override_{};
+  optional<std::set<climate::ClimatePreset>> supported_presets_override_{};
   bool supports_current_humidity_{false};
 
   sensor::Sensor *room_sensor_{};

--- a/components/daikin_s21/s21.cpp
+++ b/components/daikin_s21/s21.cpp
@@ -329,8 +329,8 @@ DaikinSerial::Result DaikinSerial::send_frame(std::string_view cmd, const std::s
     } else {
       ESP_LOGD(TAG, "Tx: %" PRI_SV " %s %s", 
                PRI_SV_ARGS(cmd),
-               str_repr({reinterpret_cast<const uint8_t *>(payload.data()), payload.size()}).c_str(),
-               hex_repr({reinterpret_cast<const uint8_t *>(payload.data()), payload.size()}).c_str());
+               str_repr(payload).c_str(),
+               hex_repr(payload).c_str());
     }
   }
 

--- a/components/daikin_s21/sensor/daikin_s21_sensor.h
+++ b/components/daikin_s21/sensor/daikin_s21_sensor.h
@@ -6,7 +6,8 @@
 namespace esphome {
 namespace daikin_s21 {
 
-class DaikinS21Sensor : public PollingComponent, public DaikinS21Client {
+class DaikinS21Sensor : public PollingComponent,
+                        public DaikinS21Client {
  public:
   void update() override;
   void dump_config() override;
@@ -37,14 +38,14 @@ class DaikinS21Sensor : public PollingComponent, public DaikinS21Client {
   }
 
  protected:
-  sensor::Sensor *temp_inside_sensor_{nullptr};
-  sensor::Sensor *temp_outside_sensor_{nullptr};
-  sensor::Sensor *temp_coil_sensor_{nullptr};
-  sensor::Sensor *fan_speed_sensor_{nullptr};
-  sensor::Sensor *swing_vertical_angle_sensor_{nullptr};
-  sensor::Sensor *compressor_frequency_sensor_{nullptr};
-  sensor::Sensor *humidity_sensor_{nullptr};
-  sensor::Sensor *demand_sensor_{nullptr};
+  sensor::Sensor *temp_inside_sensor_{};
+  sensor::Sensor *temp_outside_sensor_{};
+  sensor::Sensor *temp_coil_sensor_{};
+  sensor::Sensor *fan_speed_sensor_{};
+  sensor::Sensor *swing_vertical_angle_sensor_{};
+  sensor::Sensor *compressor_frequency_sensor_{};
+  sensor::Sensor *humidity_sensor_{};
+  sensor::Sensor *demand_sensor_{};
 };
 
 }  // namespace daikin_s21


### PR DESCRIPTION
- Add a note in the readme warning users off the Arduino framework for now.
- Add configuration of climate presets, but no underlying functionality

Additional C++20 cleanups:
- remove some unnecessary reinterpret casts
- template helpers
- default comparisons