### PR TITLE
Event driven climate and binary sensor updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ See the framework selection in the configuration example.
 
 * This code has only been tested on ESP32 pico and ESP32-S3.
 * Tested with 4MXL36TVJU outdoor unit and CTXS07LVJU, FTXS12LVJU, FTXS15LVJU indoor units.
-* Does not detect nor support powerful or econo modes.
+* Does not support powerful or econo modes.
 * Does not support comfort or presence detection features on some models.
 * Does not interact with the indoor units schedules (do that with HA instead).
 * Currently targets Version 0 protocol support due to the equipment available to the author.

--- a/components/daikin_s21/binary_sensor/__init__.py
+++ b/components/daikin_s21/binary_sensor/__init__.py
@@ -21,7 +21,7 @@ from .. import (
 )
 
 DaikinS21BinarySensor = daikin_s21_ns.class_(
-    "DaikinS21BinarySensor", cg.PollingComponent
+    "DaikinS21BinarySensor", cg.Component
 )
 
 CONF_POWERFUL = "powerful"
@@ -64,7 +64,6 @@ CONFIG_SCHEMA = (
         }
     )
     .extend(S21_PARENT_SCHEMA)
-    .extend(cv.polling_component_schema("10s"))
 )
 
 async def to_code(config):

--- a/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.cpp
+++ b/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.cpp
@@ -5,12 +5,12 @@ namespace daikin_s21 {
 
 static const char *const TAG = "daikin_s21.binary_sensor";
 
-void DaikinS21BinarySensor::update() {
-  if (!this->get_parent()->is_ready())
-    return;
+void DaikinS21BinarySensor::setup() {
+  this->get_parent()->add_binary_sensor_callback(std::bind(&DaikinS21BinarySensor::update_handler, this, std::placeholders::_1, std::placeholders::_2)); // enable update events from DaikinS21
+  this->disable_loop(); // wait for updates
+}
 
-  const auto unit_state = get_parent()->unit_state;
-  const auto system_state = get_parent()->system_state;
+void DaikinS21BinarySensor::update_handler(const uint8_t unit_state, const uint8_t system_state) {
   if (this->powerful_sensor_ != nullptr) {
     this->powerful_sensor_->publish_state(unit_state & 0x1);
   }

--- a/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.h
+++ b/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.h
@@ -8,11 +8,12 @@
 namespace esphome {
 namespace daikin_s21 {
 
-class DaikinS21BinarySensor : public PollingComponent,
+class DaikinS21BinarySensor : public Component,
                               public Parented<DaikinS21> {
  public:
-  void update() override;
+  void setup() override;
   void dump_config() override;
+  void update_handler(uint8_t unit_state, uint8_t system_state);
 
   void set_powerful_sensor(binary_sensor::BinarySensor *sensor) {
     this->powerful_sensor_ = sensor;

--- a/components/daikin_s21/climate/daikin_s21_climate.h
+++ b/components/daikin_s21/climate/daikin_s21_climate.h
@@ -16,9 +16,10 @@ class DaikinS21Climate : public climate::Climate,
                          public Parented<DaikinS21> {
  public:
   void setup() override;
-  void loop() override;
   void dump_config() override;
   void control(const climate::ClimateCall &call) override;
+  void command_timeout_handler();
+  void update_handler();
 
   void set_room_sensor(sensor::Sensor *sensor) { this->room_sensor_ = sensor; }
   void set_setpoint_interval(uint16_t seconds) { this->setpoint_interval_s = seconds; };
@@ -27,6 +28,7 @@ class DaikinS21Climate : public climate::Climate,
   void set_supports_current_humidity(bool supports_current_humidity) { this->supports_current_humidity_ = supports_current_humidity; }
 
  protected:
+  static constexpr const char * command_timeout_name = "cmd";
   static constexpr uint32_t state_publication_timeout_ms{8 * 1000}; // experimentally determined with fudge factor
 
   climate::ClimateTraits traits() override;
@@ -38,7 +40,7 @@ class DaikinS21Climate : public climate::Climate,
   uint16_t setpoint_interval_s{};
   uint32_t last_setpoint_check_ms{millis()};
 
-  uint32_t command_timeout_end_ms{millis()}; // publish current state immediately on startup
+  bool command_active{};  // ESPHome could use a is_timeout_active()...
   DaikinSettings commanded{};
 
   ESPPreferenceObject auto_setpoint_pref;
@@ -59,6 +61,7 @@ class DaikinS21Climate : public climate::Climate,
   optional<float> load_setpoint();
   bool should_check_setpoint();
   void set_s21_climate();
+  void set_command_timeout(uint32_t delay_ms = state_publication_timeout_ms);
 };
 
 }  // namespace daikin_s21

--- a/components/daikin_s21/s21.h
+++ b/components/daikin_s21/s21.h
@@ -125,7 +125,8 @@ class DaikinS21 : public PollingComponent {
   auto get_humidity() { return this->humidity; }
   auto get_demand() { return this->demand; }
 
-  bool climate_updated = false;
+  void add_climate_callback(std::function<void(void)> &&callback);
+  void add_binary_sensor_callback(std::function<void(uint8_t, uint8_t)> &&callback);
 
   // temporary stubs, hide once supported
   enum Modifier : uint8_t {
@@ -151,6 +152,9 @@ class DaikinS21 : public PollingComponent {
   void tx_next();
   void parse_ack();
   void handle_nak();
+
+  CallbackManager<void(void)> climate_callback_{};
+  CallbackManager<void(uint8_t, uint8_t)> binary_sensor_callback_{};
 
   enum ReadyCommand : uint8_t {
     ReadyProtocolVersion,


### PR DESCRIPTION
- Improves responsiveness of binary sensor values
- Reduces CPU time
- Analog sensors are meant to periodically sample as inputs to filters, keep PollingComponent there

fixes #40