### PR TITLE
Add preset support for Powerful and Econo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Climate:
 - Independent climate action reporting. See what your unit is trying to do, e.g. heating while in HEAT_COOL.
 - Fan modes auto, silent and 1-5.
 - Swing modes horizontal, vertical, and both.
+- Untested support for Powerful and Econo presets ("Boost" and "Eco").
 - Optional humidity reporting.
 
 Sensor:
@@ -48,7 +49,7 @@ See the framework selection in the configuration example.
 
 * This code has only been tested on ESP32 pico and ESP32-S3.
 * Tested with 4MXL36TVJU outdoor unit and CTXS07LVJU, FTXS12LVJU, FTXS15LVJU indoor units.
-* Does not support powerful or econo modes.
+* Powerful and econo modes are untested (no hardware).
 * Does not support comfort or presence detection features on some models.
 * Does not interact with the indoor units schedules (do that with HA instead).
 * Currently targets Version 0 protocol support due to the equipment available to the author.
@@ -148,15 +149,18 @@ climate:
     #   target_temperature: 1
     #   current_temperature: 0.5
     # Settings from DaikinS21Climate:
-    supports_humidity: true # If your unit supports humidity, it can be reported in the climate component
-    # Optional HA sensor used to alter setpoint.
-    room_temperature_sensor: room_temp  # See homeassistant sensor below
-    setpoint_interval: 300s # Interval used to adjust the unit's setpoint if the room temperature sensor is specified
     supported_modes:  # off and heat_cool are always supported
       - cool
       - heat
       - dry
       - fan_only
+    supported_presets:  # none is always supported
+      - eco
+      - boost
+    supports_humidity: true # If your unit supports humidity, it can be reported in the climate component
+    # Optional HA sensor used to alter setpoint.
+    room_temperature_sensor: room_temp  # See homeassistant sensor below
+    setpoint_interval: 300s # Interval used to adjust the unit's setpoint if the room temperature sensor is specified
 
 # Optional additional sensors.
 sensor:

--- a/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.cpp
+++ b/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.cpp
@@ -10,30 +10,30 @@ void DaikinS21BinarySensor::setup() {
   this->disable_loop(); // wait for updates
 }
 
-void DaikinS21BinarySensor::update_handler(const uint8_t unit_state, const uint8_t system_state) {
+void DaikinS21BinarySensor::update_handler(const DaikinUnitState unit, const DaikinSystemState system) {
   if (this->powerful_sensor_ != nullptr) {
-    this->powerful_sensor_->publish_state(unit_state & 0x1);
+    this->powerful_sensor_->publish_state(unit.powerful());
   }
   if (this->defrost_sensor_ != nullptr) {
-    this->defrost_sensor_->publish_state(unit_state & 0x2);
+    this->defrost_sensor_->publish_state(unit.defrost());
   }
   if (this->active_sensor_ != nullptr) {
-    this->active_sensor_->publish_state(unit_state & 0x4);  // unit
+    this->active_sensor_->publish_state(unit.active());  // unit
   }
   if (this->online_sensor_ != nullptr) {
-    this->online_sensor_->publish_state(unit_state & 0x8);
+    this->online_sensor_->publish_state(unit.online());
   }
   if (this->valve_sensor_ != nullptr) {
-    this->valve_sensor_->publish_state(system_state & 0x04);  // system
+    this->valve_sensor_->publish_state(system.active());  // refrigerant valve
   }
   if (this->short_cycle_sensor_ != nullptr) {
-    this->short_cycle_sensor_->publish_state((system_state & 0x01) == 0x00);  // invert for Home Assistant locked/unlocked logic
+    this->short_cycle_sensor_->publish_state(!system.locked());  // invert for Home Assistant locked/unlocked logic
   }
   if (this->system_defrost_sensor_ != nullptr) {
-    this->system_defrost_sensor_->publish_state(system_state & 0x08);
+    this->system_defrost_sensor_->publish_state(system.defrost());
   }
     if (this->multizone_conflict_sensor_ != nullptr) {
-    this->multizone_conflict_sensor_->publish_state((system_state & 0x20) == 0x00); // invert for Home Assistant locked/unlocked logic
+    this->multizone_conflict_sensor_->publish_state(!system.multizone_conflict()); // invert for Home Assistant locked/unlocked logic
   }
 }
 

--- a/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.h
+++ b/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.h
@@ -13,7 +13,7 @@ class DaikinS21BinarySensor : public Component,
  public:
   void setup() override;
   void dump_config() override;
-  void update_handler(uint8_t unit_state, uint8_t system_state);
+  void update_handler(DaikinUnitState unit, DaikinSystemState system_state);
 
   void set_powerful_sensor(binary_sensor::BinarySensor *sensor) {
     this->powerful_sensor_ = sensor;

--- a/components/daikin_s21/climate/daikin_s21_climate.h
+++ b/components/daikin_s21/climate/daikin_s21_climate.h
@@ -21,20 +21,18 @@ class DaikinS21Climate : public climate::Climate,
   void command_timeout_handler();
   void update_handler();
 
+  void set_supported_modes_override(std::set<climate::ClimateMode> modes);
+  void set_supported_presets_override(std::set<climate::ClimatePreset> presets);
+  void set_supports_current_humidity(bool supports_current_humidity);
   void set_room_sensor(sensor::Sensor *sensor) { this->room_sensor_ = sensor; }
   void set_setpoint_interval(uint16_t seconds) { this->setpoint_interval_s = seconds; };
-  void set_supported_modes_override(std::set<climate::ClimateMode> modes) { this->supported_modes_override_ = std::move(modes); }
-  void set_supported_presets_override(std::set<climate::ClimatePreset> presets) { this->supported_presets_override_ = std::move(presets); }
-  void set_supports_current_humidity(bool supports_current_humidity) { this->supports_current_humidity_ = supports_current_humidity; }
 
  protected:
   static constexpr const char * command_timeout_name = "cmd";
   static constexpr uint32_t state_publication_timeout_ms{8 * 1000}; // experimentally determined with fudge factor
 
-  climate::ClimateTraits traits() override;
-  optional<std::set<climate::ClimateMode>> supported_modes_override_{};
-  optional<std::set<climate::ClimatePreset>> supported_presets_override_{};
-  bool supports_current_humidity_{false};
+  climate::ClimateTraits traits_{};
+  climate::ClimateTraits traits() override { return traits_; };
 
   sensor::Sensor *room_sensor_{};
   uint16_t setpoint_interval_s{};


### PR DESCRIPTION
- Add preset to climate command structure
- Attempt to set presets
- Readout and report presets
- On unsupported units like mine, it's still possible to report powerful is active via the remote and RzB2
- Process climate action once per scan instead of on demand
- Cache climate traits. Memory increase justified by being able to remove configuration driven override state.
- Add bitfield decoders for unit state and system state

closes #50 