### PR TITLE
Add support for FTXC-A Series, only poll on the update interval.

### DIFF
--- a/components/daikin_s21/s21.h
+++ b/components/daikin_s21/s21.h
@@ -32,14 +32,14 @@ public:
     Timeout,
     Busy,
   };
-  
+
   DaikinSerial() {};
   DaikinSerial(uart::UARTComponent *tx, uart::UARTComponent *rx);
-  
+
   Result service();
   Result send_frame(std::string_view cmd, std::span<const uint8_t> payload = {});
   void flush_input();
-  
+
   std::vector<uint8_t> response{};
   bool debug{false};
 
@@ -81,7 +81,7 @@ struct DaikinC10 {
   constexpr float f_degf() const { return celsius_to_fahrenheit(static_cast<float>(*this)); }
 
   constexpr bool operator==(const DaikinC10 &other) const = default;
-  
+
 private:
   int16_t value{};
 };
@@ -102,6 +102,7 @@ class DaikinS21 : public PollingComponent {
   void update() override;
   void dump_config() override;
 
+  void run_cycle();
   void set_uarts(uart::UARTComponent *tx, uart::UARTComponent *rx) { this->serial = {tx, rx}; }
   void set_debug_comms(bool set) { this->serial.debug = set; }
   void set_debug_protocol(bool set) { this->debug_protocol = set; }
@@ -171,7 +172,7 @@ class DaikinS21 : public PollingComponent {
   std::vector<std::string_view> queries{};
   std::vector<std::string_view>::iterator current_query{};
   std::string_view tx_command{};  // used when matching responses - backing value must have persistent lifetime across serial state machine runs
-  
+
   // debugging support
   bool debug_protocol{false};
   std::unordered_map<std::string, std::vector<uint8_t>> val_cache{};
@@ -214,6 +215,7 @@ class DaikinS21 : public PollingComponent {
   bool support_swing{};
   bool support_horizontal_swing{};
   bool support_humidity{};
+  bool running_cycle{};
 };
 
 }  // namespace daikin_s21


### PR DESCRIPTION
- The expanded if when detecting the protocol makes it work with a FTXC-A Series (R32).
- Added a check so it won't report 207% humidity with this series (apparently it does not support humidity).
- Only Poll the AC on the configured polling interval instead of constantly (or when the user initiates a change).  Maybe constant polling is fine but it seems safer to not over poll the AC by design.
- Sorry about the whitespace noise, my editor removed some trailing spaces.

You should consider removing the bool from determine_protocol_version().  If it can not find the protocol the false return will leave the component in a bad state where it is talking to the AC but not reporting anything for the sensors.  Maybe this is OK since it should be able to detect the protocol but since it does not really do anything with the info just defaulting to protocol 0 might allow it work for more units.  At any rate this PR adds at least one more unit to what it will support.

If you don't want the polling changes the main thing with this PR is the tweak to protocol detection to support another unit.  In that case feel free to just take that line and close this PR.