### PR TITLE
DaikinS21 core to be configured to free running or polled

### DIFF
--- a/components/daikin_s21/__init__.py
+++ b/components/daikin_s21/__init__.py
@@ -27,7 +27,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_DEBUG_COMMS, default=False): cv.boolean,
         cv.Optional(CONF_DEBUG_PROTOCOL, default=False): cv.boolean,
     }
-).extend(cv.polling_component_schema("30s"))
+).extend(cv.polling_component_schema("0s"))
 
 S21_PARENT_SCHEMA = cv.Schema(
     {

--- a/components/daikin_s21/binary_sensor/__init__.py
+++ b/components/daikin_s21/binary_sensor/__init__.py
@@ -70,7 +70,7 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await cg.register_parented(var, config[CONF_S21_ID])
-    
+
     binary_sensors = (
         (CONF_POWERFUL, var.set_powerful_sensor),
         (CONF_DEFROST, var.set_defrost_sensor),

--- a/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.cpp
+++ b/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.cpp
@@ -1,7 +1,6 @@
 #include "daikin_s21_binary_sensor.h"
 
-namespace esphome {
-namespace daikin_s21 {
+namespace esphome::daikin_s21 {
 
 static const char *const TAG = "daikin_s21.binary_sensor";
 
@@ -49,5 +48,4 @@ void DaikinS21BinarySensor::dump_config() {
   LOG_BINARY_SENSOR("  ", "Multizone Conflict", this->multizone_conflict_sensor_);
 }
 
-}  // namespace daikin_s21
-}  // namespace esphome
+} // namespace esphome::daikin_s21

--- a/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.h
+++ b/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.h
@@ -5,8 +5,7 @@
 #include "esphome/core/helpers.h"
 #include "../s21.h"
 
-namespace esphome {
-namespace daikin_s21 {
+namespace esphome::daikin_s21 {
 
 class DaikinS21BinarySensor : public Component,
                               public Parented<DaikinS21> {
@@ -51,5 +50,4 @@ class DaikinS21BinarySensor : public Component,
   binary_sensor::BinarySensor *multizone_conflict_sensor_{};
 };
 
-}  // namespace daikin_s21
-}  // namespace esphome
+} // namespace esphome::daikin_s21

--- a/components/daikin_s21/climate/__init__.py
+++ b/components/daikin_s21/climate/__init__.py
@@ -68,6 +68,6 @@ async def to_code(config):
 
     if CONF_SUPPORTED_PRESETS in config:
         cg.add(var.set_supported_presets_override(config[CONF_SUPPORTED_PRESETS]))
-    
+
     if CONF_SUPPORTS_HUMIDITY in config:
         cg.add(var.set_supports_current_humidity(config[CONF_SUPPORTS_HUMIDITY]))

--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -7,8 +7,7 @@
 
 using namespace esphome;
 
-namespace esphome {
-namespace daikin_s21 {
+namespace esphome::daikin_s21 {
 
 constexpr float SETPOINT_STEP = 0.5F; // ESPHome thermostat calculations -- unit's internal support and visual step may differ
 
@@ -35,8 +34,8 @@ void DaikinS21Climate::setup() {
       climate::CLIMATE_MODE_DRY,
   });
   std::array<std::string, std::size(supported_daikin_fan_modes)> supported_fan_mode_strings;
-  std::ranges::transform(supported_daikin_fan_modes, std::begin(supported_fan_mode_strings), [](const auto &arg){ return daikin_fan_mode_to_string_view(arg); } );
-  this->traits_.set_supported_custom_fan_modes({std::begin(supported_fan_mode_strings), std::end(supported_fan_mode_strings)});
+  std::ranges::transform(supported_daikin_fan_modes, supported_fan_mode_strings.begin(), [](const auto &arg){ return daikin_fan_mode_to_string_view(arg); } );
+  this->traits_.set_supported_custom_fan_modes({supported_fan_mode_strings.begin(), supported_fan_mode_strings.end()});
   this->traits_.set_supported_swing_modes({
       climate::CLIMATE_SWING_OFF,
       climate::CLIMATE_SWING_BOTH,
@@ -53,7 +52,7 @@ void DaikinS21Climate::setup() {
 }
 /**
  * Command timeout handler
- * 
+ *
  * Called when a command times out without seeming to take effect.
  * Trigger a publish of the current state.
  */
@@ -64,7 +63,7 @@ void DaikinS21Climate::command_timeout_handler() {
 
 /**
  * Update handler
- * 
+ *
  * Update climate state if a previous command isn't in progress.
  * Publish any state changes to Home Assistant.
  *
@@ -78,7 +77,7 @@ void DaikinS21Climate::update_handler() {
     this->command_active = false;
     this->cancel_timeout(command_timeout_name);
   }
-  
+
   // Don't publish current state if a command is in progress -- avoids UI glitches
   if (command_active == false) {
     // Allowed to publish, determine if we should
@@ -168,7 +167,7 @@ void DaikinS21Climate::dump_config() {
  * Override supported modes
  *
  * @note Modifies traits, call during setup only
- * 
+ *
  * @param modes modes to support
  */
 void DaikinS21Climate::set_supported_modes_override(std::set<climate::ClimateMode> modes) {
@@ -181,7 +180,7 @@ void DaikinS21Climate::set_supported_modes_override(std::set<climate::ClimateMod
  * Override supported presets
  *
  * @note Modifies traits, call during setup only
- * 
+ *
  * @param presets presets to support
  */
 void DaikinS21Climate::set_supported_presets_override(std::set<climate::ClimatePreset> presets) {
@@ -193,7 +192,7 @@ void DaikinS21Climate::set_supported_presets_override(std::set<climate::ClimateP
  * Configure to report humidity
  *
  * @note Modifies traits, call during setup only
- * 
+ *
  * @param supports_current_humidity true to report humidity, false to disable
  */
 void DaikinS21Climate::set_supports_current_humidity(const bool supports_current_humidity) {
@@ -202,7 +201,7 @@ void DaikinS21Climate::set_supports_current_humidity(const bool supports_current
 
 void DaikinS21Climate::set_custom_fan_mode(const DaikinFanMode mode) {
   this->commanded.fan = mode;
-  this->custom_fan_mode = static_cast<std::string>(daikin_fan_mode_to_string_view(mode)); 
+  this->custom_fan_mode = static_cast<std::string>(daikin_fan_mode_to_string_view(mode));
 }
 
 bool DaikinS21Climate::use_room_sensor() {
@@ -318,7 +317,7 @@ bool DaikinS21Climate::should_check_setpoint() {
 
 /**
  * Inherited ESPHome climate control call handler.
- * 
+ *
  * Populates internal state with contained arguments then applies to the unit.
  *
  * @param call the call to process
@@ -383,7 +382,7 @@ void DaikinS21Climate::set_s21_climate() {
  * takes effect or is given enough time to take effect or we get a jumpy UI
  * in Home Assistant as stale state is published over the commanded state
  * followed by the active state.
- * 
+ *
  * If the timeout expires the state will be published regardless.
  */
 void DaikinS21Climate::set_command_timeout(const uint32_t delay_ms /*= state_publication_timeout_ms*/) {
@@ -391,5 +390,4 @@ void DaikinS21Climate::set_command_timeout(const uint32_t delay_ms /*= state_pub
   this->set_timeout(command_timeout_name, delay_ms, std::bind(&DaikinS21Climate::command_timeout_handler, this));
 }
 
-}  // namespace daikin_s21
-}  // namespace esphome
+} // namespace esphome::daikin_s21

--- a/components/daikin_s21/climate/daikin_s21_climate.h
+++ b/components/daikin_s21/climate/daikin_s21_climate.h
@@ -8,8 +8,7 @@
 #include "../daikin_s21_fan_modes.h"
 #include "../s21.h"
 
-namespace esphome {
-namespace daikin_s21 {
+namespace esphome::daikin_s21 {
 
 class DaikinS21Climate : public climate::Climate,
                          public Component,
@@ -62,5 +61,4 @@ class DaikinS21Climate : public climate::Climate,
   void set_command_timeout(uint32_t delay_ms = state_publication_timeout_ms);
 };
 
-}  // namespace daikin_s21
-}  // namespace esphome
+} // namespace esphome::daikin_s21

--- a/components/daikin_s21/daikin_s21_fan_modes.h
+++ b/components/daikin_s21/daikin_s21_fan_modes.h
@@ -3,8 +3,7 @@
 #include <cstdint>
 #include <string_view>
 
-namespace esphome {
-namespace daikin_s21 {
+namespace esphome::daikin_s21 {
 
 enum class DaikinFanMode : uint8_t {
   Auto = 'A',
@@ -55,5 +54,4 @@ constexpr DaikinFanMode string_to_daikin_fan_mode(const std::string_view mode) {
   return DaikinFanMode::Auto;
 }
 
-}  // namespace daikin_s21
-}  // namespace esphome
+} // namespace esphome::daikin_s21

--- a/components/daikin_s21/daikin_s21_queries.h
+++ b/components/daikin_s21/daikin_s21_queries.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <string_view>
+
+namespace esphome::daikin_s21 {
+
+namespace StateQuery {
+  inline constexpr std::string_view Basic{"F1"};
+  inline constexpr std::string_view OptionalFeatures{"F2"};
+  inline constexpr std::string_view OnOffTimer{"F3"};
+  inline constexpr std::string_view ErrorStatus{"F4"};
+  inline constexpr std::string_view SwingOrHumidity{"F5"};
+  inline constexpr std::string_view SpecialModes{"F6"};
+  inline constexpr std::string_view DemandAndEcono{"F7"};
+  inline constexpr std::string_view OldProtocol{"F8"};
+  inline constexpr std::string_view InsideOutsideTemperatures{"F9"};
+  // FA
+  // FB
+  inline constexpr std::string_view ModelCode{"FC"};
+  inline constexpr std::string_view IRCounter{"FG"};
+  inline constexpr std::string_view V2OptionalFeatures{"FK"};
+  // FL
+  inline constexpr std::string_view PowerConsumption{"FM"};
+  // FN
+  // FP
+  // FQ
+  inline constexpr std::string_view LouvreAngle{"FR"};
+  // FS
+  // FT
+  inline constexpr std::string_view V3OptionalFeatures{"FU00"};
+  inline constexpr std::string_view AllowedTemperatureRange{"FU02"};
+  // FU04
+  inline constexpr std::string_view ModelName{"FU05"};
+  inline constexpr std::string_view ProductionInformation{"FU15"};
+  inline constexpr std::string_view ProductionOrder{"FU25"};
+  inline constexpr std::string_view IndoorProductionInformation{"FU35"};
+  inline constexpr std::string_view OutdoorProductionInformation{"FU45"};
+  // FV
+  // FX00
+  // FX10
+  // FX20
+  // FX30
+  // FX40
+  // FX50
+  // FX60
+  // FX70
+  // FX80
+  // FX90
+  // FXA0
+  // FXB0
+  // FXC0
+  // FXD0
+  // FXE0
+  // FXF0
+  // FX01
+  // FX11
+  // FX21
+  // FX31
+  // FX41
+  // FX51
+  // FX61
+  // FX71
+  // FX81
+  inline constexpr std::string_view NewProtocol{"FY00"};
+  // FY10
+  // FY20
+} // namespace StateQuery
+
+namespace EnvironmentQuery {
+  inline constexpr std::string_view PowerOnOff{"RA"};
+  inline constexpr std::string_view IndoorUnitMode{"RB"};
+  inline constexpr std::string_view TemperatureSetPoint{"RC"};
+  inline constexpr std::string_view OnTimerSetting{"RD"};
+  inline constexpr std::string_view OffTimerSetting{"RE"};
+  // RF
+  inline constexpr std::string_view FanMode{"RG"};
+  inline constexpr std::string_view InsideTemperature{"RH"};
+  inline constexpr std::string_view LiquidTemperature{"RI"};
+  inline constexpr std::string_view FanSetPoint{"RK"};
+  inline constexpr std::string_view FanSpeed{"RL"};
+  inline constexpr std::string_view LouvreAngleSetPoint{"RM"};
+  inline constexpr std::string_view VerticalSwingAngle{"RN"};
+  // RW
+  inline constexpr std::string_view TargetTemperature{"RX"}; // (not set point, see details)
+  inline constexpr std::string_view OutsideTemperature{"Ra"};
+  inline constexpr std::string_view IndoorFrequencyCommandSignal{"Rb"};
+  inline constexpr std::string_view CompressorFrequency{"Rd"};
+  inline constexpr std::string_view IndoorHumidity{"Re"};
+  inline constexpr std::string_view CompressorOnOff{"Rg"};
+  inline constexpr std::string_view UnitState{"RzB2"};
+  inline constexpr std::string_view SystemState{"RzC3"};
+  // Rz52
+  // Rz72
+} // namespace EnvironmentQuery
+
+namespace MiscQuery {
+  inline constexpr std::string_view Model{"M"};
+  inline constexpr std::string_view Version{"V"};
+} // namespace MiscQuery
+
+namespace StateCommand {
+  inline constexpr std::string_view PowerModeTempFan{"D1"};
+  // D2
+  inline constexpr std::string_view OnOffTimer{"D3"};
+  inline constexpr std::string_view LouvreSwing{"D5"};
+  inline constexpr std::string_view Powerful{"D6"};
+  inline constexpr std::string_view Econo{"D7"};
+  // DH
+  // DJ
+  // DR
+}
+
+} // namespace esphome::daikin_s21

--- a/components/daikin_s21/sensor/daikin_s21_sensor.cpp
+++ b/components/daikin_s21/sensor/daikin_s21_sensor.cpp
@@ -1,7 +1,6 @@
 #include "daikin_s21_sensor.h"
 
-namespace esphome {
-namespace daikin_s21 {
+namespace esphome::daikin_s21 {
 
 static const char *const TAG = "daikin_s21.sensor";
 
@@ -46,5 +45,4 @@ void DaikinS21Sensor::dump_config() {
   LOG_SENSOR("  ", "Demand", this->demand_sensor_);
 }
 
-}  // namespace daikin_s21
-}  // namespace esphome
+} // namespace esphome::daikin_s21

--- a/components/daikin_s21/sensor/daikin_s21_sensor.h
+++ b/components/daikin_s21/sensor/daikin_s21_sensor.h
@@ -5,8 +5,7 @@
 #include "esphome/core/helpers.h"
 #include "../s21.h"
 
-namespace esphome {
-namespace daikin_s21 {
+namespace esphome::daikin_s21 {
 
 class DaikinS21Sensor : public PollingComponent,
                         public Parented<DaikinS21> {
@@ -50,5 +49,4 @@ class DaikinS21Sensor : public PollingComponent,
   sensor::Sensor *demand_sensor_{};
 };
 
-}  // namespace daikin_s21
-}  // namespace esphome
+} // namespace esphome::daikin_s21


### PR DESCRIPTION
- Add modified version of @sstanfield's logic
- Fix protocol 2.0 detection for FTXC-A (thanks @sstanfield)
- Don't interpret out of range humidity value (thanks @sstanfield)
- Predefine query strings (thanks @wolffshots)
- C++17 nested namespaces
- Strip trailing whitespace
- Use `this` a little more
- Fix issue where preset commands were issued unnecessarily