### PR TITLE
Add split_uart component to abstract the original dual UART

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ESPHome component to control Daikin indoor mini-split units with s21 ports.
 
 Many thanks to the work by [revk][1] on the fantastic [Faikin][2] project, which
-was the primary inspiration and guide for building this ESPHome component. In 
+was the primary inspiration and guide for building this ESPHome component. In
 addition, the very active and resourceful community that project has fostered
 that has decoded much of the protocol.
 
@@ -77,7 +77,7 @@ plug pins are at standard 2.5mm pin header widths.
 joshbenner uses the board designed by [revk][1] available [here][3]. Note that
 revk's design includes a FET that inverts the logic levels on the ESP's RX pin,
 which required using two separate UART devices to get around an ESPHome limit
-on having pins inverted differently.
+on having pins inverted differently using the Arduino framework.
 
 ### PCB Option 2
 
@@ -108,8 +108,9 @@ encounter issues and help me learn more about the output of different models.
 * Let me know how useful the binary sensor values are and which just shadow other
 sensor values.
 * If you have a revk module with an inverting RX pin, let me know if using a single
-UART configuration and inverting the RX line with ESPHome's pin schema works. If so,
-I can remove this custom code and simplify configuration and the internal code.
+UART configuration and inverting the RX line with ESPHome's pin schema works with
+ESP-IDF and (when it's working again) the Arduino framework. i.e. Not using the
+split_uart component. If so, I can remove this custom code and simplify configuration.
 
 See existing issues or open a new one with your findings. Thanks.
 
@@ -128,7 +129,7 @@ logger:
 
 external_components:
   - source: github://asund/esphome-daikin-s21@main
-    components: [ daikin_s21 ]
+    components: [ daikin_s21, split_uart ]
 
 uart:
   - id: s21_uart
@@ -136,10 +137,10 @@ uart:
     rx_pin: GPIO3
     baud_rate: 2400
 
-# The base UART communication hub.
+# The parent UART communication hub platform.
 daikin_s21:
-  tx_uart: s21_uart
-  rx_uart: s21_uart
+  uart_id: s21_uart
+  # update_interval: 15s  # supports periodic polling instead of more responsive free run
 
 climate:
   - name: My Daikin
@@ -181,7 +182,7 @@ sensor:
       name: Humidity
     demand:
       name: Demand  # 0-15 demand units, use filter to map to %
-      filters:  
+      filters:
         - multiply: !lambda return 100.0F / 15.0F;
   - platform: homeassistant
     id: room_temp
@@ -226,12 +227,16 @@ uart:
     parity: EVEN
     stop_bits: 2
 
-daikin_s21:
+split_uart:
+  id: split_uart_1
   tx_uart: s21_tx
   rx_uart: s21_rx
+
+daikin_s21:
+  uart_id: split_uart_1
 ```
 
-Here's an example of a single UART using direct wiring:
+Here's an example of a single UART using direct wiring (you can leave out the split_uart component import as well):
 
 ```yaml
 uart:
@@ -243,8 +248,7 @@ uart:
         open_drain: true  # daikin pulls up to 5V internally
     rx_pin: GPIO44
     baud_rate: 2400
-  
+
 daikin_s21:
-  tx_uart: s21_uart
-  rx_uart: s21_uart
+  uart_id: s21_uart
 ```

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ uart:
 
 # The parent UART communication hub platform.
 daikin_s21:
-  uart_id: s21_uart
+  uart: s21_uart
   # update_interval: 15s  # supports periodic polling instead of more responsive free run
 
 climate:
@@ -233,7 +233,7 @@ split_uart:
   rx_uart: s21_rx
 
 daikin_s21:
-  uart_id: split_uart_1
+  uart: split_uart_1
 ```
 
 Here's an example of a single UART using direct wiring (you can leave out the split_uart component import as well):
@@ -250,5 +250,5 @@ uart:
     baud_rate: 2400
 
 daikin_s21:
-  uart_id: s21_uart
+  uart: s21_uart
 ```

--- a/components/daikin_s21/__init__.py
+++ b/components/daikin_s21/__init__.py
@@ -4,12 +4,13 @@ Daikin S21 Mini-Split ESPHome component config validation & code generation.
 
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
+from esphome.const import (
+  CONF_ID,
+  CONF_UART_ID,
+)
 
 DEPENDENCIES = ["uart"]
 
-CONF_TX_UART = "tx_uart"
-CONF_RX_UART = "rx_uart"
 CONF_S21_ID = "s21_id"
 CONF_DEBUG_COMMS = "debug_comms"
 CONF_DEBUG_PROTOCOL = "debug_protocol"
@@ -22,8 +23,7 @@ UARTComponent = uart_ns.class_("UARTComponent")
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(DaikinS21),
-        cv.Required(CONF_TX_UART): cv.use_id(UARTComponent),
-        cv.Required(CONF_RX_UART): cv.use_id(UARTComponent),
+        cv.Required(CONF_UART_ID): cv.use_id(UARTComponent),
         cv.Optional(CONF_DEBUG_COMMS, default=False): cv.boolean,
         cv.Optional(CONF_DEBUG_PROTOCOL, default=False): cv.boolean,
     }
@@ -36,11 +36,8 @@ S21_PARENT_SCHEMA = cv.Schema(
 )
 
 async def to_code(config):
-    """Generate code"""
-    var = cg.new_Pvariable(config[CONF_ID])
+    uart = await cg.get_variable(config[CONF_UART_ID])
+    var = cg.new_Pvariable(config[CONF_ID], uart)
     await cg.register_component(var, config)
-    tx_uart = await cg.get_variable(config[CONF_TX_UART])
-    rx_uart = await cg.get_variable(config[CONF_RX_UART])
-    cg.add(var.set_uarts(tx_uart, rx_uart))
     cg.add(var.set_debug_comms(config[CONF_DEBUG_COMMS]))
     cg.add(var.set_debug_protocol(config[CONF_DEBUG_PROTOCOL]))

--- a/components/daikin_s21/__init__.py
+++ b/components/daikin_s21/__init__.py
@@ -6,12 +6,12 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.const import (
   CONF_ID,
-  CONF_UART_ID,
 )
 
 DEPENDENCIES = ["uart"]
 
 CONF_S21_ID = "s21_id"
+CONF_UART = "uart"
 CONF_DEBUG_COMMS = "debug_comms"
 CONF_DEBUG_PROTOCOL = "debug_protocol"
 
@@ -23,7 +23,7 @@ UARTComponent = uart_ns.class_("UARTComponent")
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(DaikinS21),
-        cv.Required(CONF_UART_ID): cv.use_id(UARTComponent),
+        cv.Required(CONF_UART): cv.use_id(UARTComponent),
         cv.Optional(CONF_DEBUG_COMMS, default=False): cv.boolean,
         cv.Optional(CONF_DEBUG_PROTOCOL, default=False): cv.boolean,
     }
@@ -36,7 +36,7 @@ S21_PARENT_SCHEMA = cv.Schema(
 )
 
 async def to_code(config):
-    uart = await cg.get_variable(config[CONF_UART_ID])
+    uart = await cg.get_variable(config[CONF_UART])
     var = cg.new_Pvariable(config[CONF_ID], uart)
     await cg.register_component(var, config)
     cg.add(var.set_debug_comms(config[CONF_DEBUG_COMMS]))

--- a/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.cpp
+++ b/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.cpp
@@ -5,7 +5,7 @@ namespace esphome::daikin_s21 {
 static const char *const TAG = "daikin_s21.binary_sensor";
 
 void DaikinS21BinarySensor::setup() {
-  this->get_parent()->add_binary_sensor_callback(std::bind(&DaikinS21BinarySensor::update_handler, this, std::placeholders::_1, std::placeholders::_2)); // enable update events from DaikinS21
+  this->get_parent()->binary_sensor_callback = std::bind(&DaikinS21BinarySensor::update_handler, this, std::placeholders::_1, std::placeholders::_2); // enable update events from DaikinS21
   this->disable_loop(); // wait for updates
 }
 

--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -9,9 +9,9 @@ using namespace esphome;
 
 namespace esphome::daikin_s21 {
 
-constexpr float SETPOINT_STEP = 0.5F; // ESPHome thermostat calculations -- unit's internal support and visual step may differ
-
 static const char *const TAG = "daikin_s21.climate";
+
+constexpr float SETPOINT_STEP = 0.5F; // ESPHome thermostat calculations -- unit's internal support and visual step may differ
 
 void DaikinS21Climate::setup() {
   uint32_t h = this->get_object_id_hash();
@@ -46,7 +46,7 @@ void DaikinS21Climate::setup() {
   this->set_custom_fan_mode(commanded.fan);
   this->preset = commanded.preset;
   // enable event driven updates
-  this->get_parent()->add_climate_callback(std::bind(&DaikinS21Climate::update_handler, this)); // enable update events from DaikinS21
+  this->get_parent()->climate_callback = std::bind(&DaikinS21Climate::update_handler, this); // enable update events from DaikinS21
   this->set_command_timeout(0);  // schedule an immediate update to capture the current state (change detection on update requires a "previous" state)
   this->disable_loop(); // wait for updates
 }

--- a/components/daikin_s21/s21.cpp
+++ b/components/daikin_s21/s21.cpp
@@ -521,8 +521,12 @@ void DaikinS21::do_next_action() {
         this->active.preset = climate::CLIMATE_PRESET_NONE;
       }
       // signal there's fresh data
-      this->binary_sensor_callback_.call(this->unit_state, this->system_state);
-      this->climate_callback_.call();
+      if (this->binary_sensor_callback) {
+        this->binary_sensor_callback(this->unit_state, this->system_state);
+      }
+      if (this->climate_callback) {
+        this->climate_callback();
+      }
     }
     if ((now - last_state_dump_ms) > (60 * 1000)) {
       last_state_dump_ms = now;
@@ -1007,14 +1011,6 @@ climate::ClimateAction DaikinS21::resolve_climate_action() {
       break;
   }
   return this->action_reported;
-}
-
-void DaikinS21::add_climate_callback(std::function<void(void)> &&callback) {
-  this->climate_callback_.add(std::move(callback));
-}
-
-void DaikinS21::add_binary_sensor_callback(std::function<void(DaikinUnitState, DaikinSystemState)> &&callback) {
-  this->binary_sensor_callback_.add(std::move(callback));
 }
 
 } // namespace esphome::daikin_s21

--- a/components/daikin_s21/s21.cpp
+++ b/components/daikin_s21/s21.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <cinttypes>
 #include <numeric>
+#include "esphome/core/application.h"
 #include "s21.h"
 
 using namespace esphome;
@@ -108,17 +109,12 @@ int16_t bytes_to_num(std::span<const uint8_t> bytes) {
   return val;
 }
 
-DaikinSerial::DaikinSerial(uart::UARTComponent *tx, uart::UARTComponent *rx) {
-  this->tx_uart = tx;
-  this->rx_uart = rx;
-
-  for (auto *uart : {this->tx_uart, this->rx_uart}) {
-    uart->set_baud_rate(2400);
-    uart->set_stop_bits(2);
-    uart->set_data_bits(8);
-    uart->set_parity(uart::UART_CONFIG_PARITY_EVEN);
-    uart->load_settings();
-  }
+DaikinSerial::DaikinSerial(uart::UARTComponent &uart) : uart(uart) {
+  this->uart.set_baud_rate(2400);
+  this->uart.set_stop_bits(2);
+  this->uart.set_data_bits(8);
+  this->uart.set_parity(uart::UART_CONFIG_PARITY_EVEN);
+  this->uart.load_settings();
 }
 
 void DaikinS21::dump_config() {
@@ -255,6 +251,14 @@ DaikinSerial::Result DaikinSerial::service() {
   switch (this->comm_state) {
     case CommState::AckResponseDelay:
       delay_period_ms = 45; // official remote delay time before ACKing a response
+      {
+        // Reduce the delay period by the number of character times waiting for the scheduler
+        // to call loop() since the final ETX was received. This is very minor and can go away
+        // once TODO this is timer event driven.
+        constexpr uint32_t char_time = 1000 / (2400 / (1+8+2+1));
+        const int chars_per_loop = App.get_loop_interval() / char_time;
+        delay_period_ms -= std::max(chars_per_loop - this->rx_bytes_last_call, 0) * char_time;
+      }
       break;
     case CommState::NextTxDelay:
       delay_period_ms = 35; // official remote delay time between commands
@@ -266,12 +270,12 @@ DaikinSerial::Result DaikinSerial::service() {
       delay_period_ms = 250;  // character timeout when expecting a response from the unit
       break;
   }
-  bool timeout = (now - last_event_time_ms) > delay_period_ms;
+  const bool timeout = (now - this->last_event_time_ms) > delay_period_ms;
 
   switch (this->comm_state) {
     case CommState::AckResponseDelay:
       if (timeout) {
-        this->tx_uart->write_byte(ACK);
+        this->uart.write_byte(ACK);
         this->last_event_time_ms = now;
         this->comm_state = CommState::NextTxDelay;
       }
@@ -292,11 +296,13 @@ DaikinSerial::Result DaikinSerial::service() {
         result = Result::Timeout;
         break;
       }
-      while ((result == Result::Busy) && this->rx_uart->available()) {  // read all available bytes
+      this->rx_bytes_last_call = 0;
+      while ((result == Result::Busy) && this->uart.available()) {  // read all available bytes
         last_event_time_ms = now;
         uint8_t byte;
-        this->rx_uart->read_byte(&byte);
+        this->uart.read_byte(&byte);
         result = this->handle_rx(byte);
+        this->rx_bytes_last_call++;
       }
       break;
   }
@@ -330,18 +336,18 @@ DaikinSerial::Result DaikinSerial::send_frame(std::string_view cmd, const std::s
   this->flush_input();
 
   // transmit
-  this->tx_uart->write_byte(STX);
-  this->tx_uart->write_array(reinterpret_cast<const uint8_t *>(cmd.data()), cmd.size());
+  this->uart.write_byte(STX);
+  this->uart.write_array(reinterpret_cast<const uint8_t *>(cmd.data()), cmd.size());
   uint8_t checksum = std::reduce(cmd.begin(), cmd.end(), 0U);
   if (payload.empty() == false) {
-    this->tx_uart->write_array(payload.data(), payload.size());
+    this->uart.write_array(payload.data(), payload.size());
     checksum = std::reduce(payload.begin(), payload.end(), checksum);
   }
   if (checksum == STX) {
     checksum = ENQ;  // mid-message STX characters are escaped
   }
-  this->tx_uart->write_byte(checksum);
-  this->tx_uart->write_byte(ETX);
+  this->uart.write_byte(checksum);
+  this->uart.write_byte(ETX);
 
   // wait for result
   this->last_event_time_ms = millis();
@@ -351,9 +357,9 @@ DaikinSerial::Result DaikinSerial::send_frame(std::string_view cmd, const std::s
 }
 
 void DaikinSerial::flush_input() {  // would be a nice ESPHome API improvement
-  while (this->rx_uart->available()) {
+  while (this->uart.available()) {
     uint8_t byte;
-    this->rx_uart->read_byte(&byte);
+    this->uart.read_byte(&byte);
   }
 }
 

--- a/components/daikin_s21/s21.h
+++ b/components/daikin_s21/s21.h
@@ -2,6 +2,7 @@
 
 #include <bitset>
 #include <compare>
+#include <functional>
 #include <limits>
 #include <span>
 #include <string>
@@ -65,7 +66,8 @@ private:
 /**
  * Class representing a temperature in degrees C scaled by 10, the most granular internal temperature measurement format
  */
-struct DaikinC10 {
+class DaikinC10 {
+ public:
   constexpr DaikinC10() = default;
 
   template <typename T, typename std::enable_if_t<std::is_floating_point_v<T>, bool> = true>
@@ -81,14 +83,15 @@ struct DaikinC10 {
 
   constexpr bool operator==(const DaikinC10 &other) const = default;
 
-private:
+ private:
   int16_t value{};
 };
 
 /**
  * Unit state (RzB2) bitfield decoder
  */
-struct DaikinUnitState {
+class DaikinUnitState {
+ public:
   constexpr DaikinUnitState(const uint8_t value = 0U) : raw(value) {}
   constexpr bool powerful() const { return (this->raw & 0x1) != 0; }
   constexpr bool defrost() const { return (this->raw & 0x2) != 0; }
@@ -100,7 +103,8 @@ struct DaikinUnitState {
 /**
  * System state (RzC3) bitfield decoder
  */
-struct DaikinSystemState {
+class DaikinSystemState {
+ public:
   constexpr DaikinSystemState(const uint8_t value = 0U) : raw(value) {}
   constexpr bool locked() const { return (this->raw & 0x01) != 0; }
   constexpr bool active() const { return (this->raw & 0x04) != 0; }
@@ -134,8 +138,8 @@ class DaikinS21 : public PollingComponent {
   // external command action
   void set_climate_settings(const DaikinSettings &settings);
 
-  void add_climate_callback(std::function<void(void)> &&callback);
-  void add_binary_sensor_callback(std::function<void(DaikinUnitState, DaikinSystemState)> &&callback);
+  std::function<void(void)> climate_callback{};
+  std::function<void(DaikinUnitState, DaikinSystemState)> binary_sensor_callback{};
 
   // value accessors
   bool is_ready() { return this->ready.all(); }
@@ -160,9 +164,6 @@ class DaikinS21 : public PollingComponent {
   void do_next_action();
   void parse_ack();
   void handle_nak();
-
-  CallbackManager<void(void)> climate_callback_{};
-  CallbackManager<void(DaikinUnitState, DaikinSystemState)> binary_sensor_callback_{};
 
   enum ReadyCommand : uint8_t {
     ReadyProtocolVersion,

--- a/components/daikin_s21/s21.h
+++ b/components/daikin_s21/s21.h
@@ -33,8 +33,7 @@ public:
     Busy,
   };
 
-  DaikinSerial() {};
-  DaikinSerial(uart::UARTComponent *tx, uart::UARTComponent *rx);
+  DaikinSerial(uart::UARTComponent &uart);
 
   Result service();
   Result send_frame(std::string_view cmd, std::span<const uint8_t> payload = {});
@@ -57,9 +56,9 @@ private:
     ErrorDelay,
   };
 
-  uart::UARTComponent *tx_uart{};
-  uart::UARTComponent *rx_uart{};
+  uart::UARTComponent &uart;
   CommState comm_state{};
+  uint8_t rx_bytes_last_call{};
   uint32_t last_event_time_ms{};
 };
 
@@ -122,12 +121,13 @@ struct DaikinSettings {
 
 class DaikinS21 : public PollingComponent {
  public:
+  DaikinS21(uart::UARTComponent *uart) : serial(*uart) {} // required in config, non-null
+
   void setup() override;
   void loop() override;
   void update() override;
   void dump_config() override;
 
-  void set_uarts(uart::UARTComponent *tx, uart::UARTComponent *rx) { this->serial = {tx, rx}; }
   void set_debug_comms(bool set) { this->serial.debug = set; }
   void set_debug_protocol(bool set) { this->debug_protocol = set; }
 

--- a/components/split_uart/__init__.py
+++ b/components/split_uart/__init__.py
@@ -1,0 +1,35 @@
+"""
+Split UART component for ESPHome. Combines two UARTs into one to workaround an Arduino framework limitation with different pin invert settings.
+"""
+
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import uart
+from esphome.const import CONF_ID
+
+DEPENDENCIES = ["uart"]
+
+CONF_TX_UART = "tx_uart"
+CONF_RX_UART = "rx_uart"
+
+split_uart_component_ns = cg.esphome_ns.namespace("split_uart")
+SplitUART = split_uart_component_ns.class_("SplitUART", uart.UARTComponent, cg.Component)
+uart_ns = cg.esphome_ns.namespace("uart")
+UARTComponent = uart_ns.class_("UARTComponent")
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(SplitUART),
+            cv.Required(CONF_TX_UART): cv.use_id(UARTComponent),
+            cv.Required(CONF_RX_UART): cv.use_id(UARTComponent),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+async def to_code(config):
+    tx_uart = await cg.get_variable(config[CONF_TX_UART])
+    rx_uart = await cg.get_variable(config[CONF_RX_UART])
+    var = cg.new_Pvariable(config[CONF_ID], tx_uart, rx_uart)
+    await cg.register_component(var, config)

--- a/components/split_uart/split_uart.h
+++ b/components/split_uart/split_uart.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/uart/uart.h"
+
+namespace esphome::split_uart {
+
+/**
+ * Split UART Component
+ *
+ * Wraps two underlying UARTs to allow reads and writes to be directed to different sub-components from a single interface.
+ */
+class SplitUART : public uart::UARTComponent, public Component {
+public:
+  SplitUART(uart::UARTComponent *tx, uart::UARTComponent *rx) : tx(tx), rx(rx) {}
+
+  // Component overrides
+
+  void setup() override {
+    this->disable_loop(); // just a proxy, nothing happening here
+  }
+
+  // UARTComponent overrides
+
+  void write_array(const uint8_t *data, size_t len) override {
+    return this->tx->write_array(data, len);
+  }
+
+  bool peek_byte(uint8_t *data) override {
+    return this->rx->peek_byte(data);
+  }
+
+  bool read_array(uint8_t *data, size_t len) override {
+    return this->rx->read_array(data, len);
+  }
+
+  int available() override {
+    return this->rx->available();
+  }
+
+  void flush() override {
+    return this->tx->flush();
+  }
+
+  void load_settings(bool dump_config) override {
+    for (auto *uart : {this->tx, this->rx}) {
+      // no support for different UART settings
+      uart->set_baud_rate(this->get_baud_rate());
+      uart->set_stop_bits(this->get_stop_bits());
+      uart->set_data_bits(this->get_data_bits());
+      uart->set_parity(this->get_parity());
+      uart->load_settings(dump_config);
+    }
+  }
+
+  void load_settings() override {
+    this->load_settings(true);
+  }
+
+protected:
+  void check_logger_conflict() override {}  // checked by subcomponent
+
+  uart::UARTComponent *tx{};
+  uart::UARTComponent *rx{};
+};
+
+}  // namespace esphome::daikin_s21

--- a/components/split_uart/split_uart.h
+++ b/components/split_uart/split_uart.h
@@ -11,7 +11,7 @@ namespace esphome::split_uart {
  * Wraps two underlying UARTs to allow reads and writes to be directed to different sub-components from a single interface.
  */
 class SplitUART : public uart::UARTComponent, public Component {
-public:
+ public:
   SplitUART(uart::UARTComponent *tx, uart::UARTComponent *rx) : tx(tx), rx(rx) {}
 
   // Component overrides
@@ -22,15 +22,15 @@ public:
 
   // UARTComponent overrides
 
-  void write_array(const uint8_t *data, size_t len) override {
+  void write_array(const uint8_t * const data, const size_t len) override {
     return this->tx->write_array(data, len);
   }
 
-  bool peek_byte(uint8_t *data) override {
+  bool peek_byte(uint8_t * const data) override {
     return this->rx->peek_byte(data);
   }
 
-  bool read_array(uint8_t *data, size_t len) override {
+  bool read_array(uint8_t * const data, const size_t len) override {
     return this->rx->read_array(data, len);
   }
 
@@ -42,7 +42,7 @@ public:
     return this->tx->flush();
   }
 
-  void load_settings(bool dump_config) override {
+  void load_settings(const bool dump_config) override {
     for (auto *uart : {this->tx, this->rx}) {
       // no support for different UART settings
       uart->set_baud_rate(this->get_baud_rate());
@@ -57,9 +57,7 @@ public:
     this->load_settings(true);
   }
 
-protected:
-  void check_logger_conflict() override {}  // checked by subcomponent
-
+ protected:
   uart::UARTComponent *tx{};
   uart::UARTComponent *rx{};
 };


### PR DESCRIPTION
- Update daikin_s21 configuration schema: specify a single UART with `uart`. Sorry if this breaks your config.
- If the original dual UART implementation is required, add a split_uart to manage them. See README.
- Replace some required pointers with references
- Add Ack delay offset optimization. Closes #55 