### PR TITLE
Move serial state machine into separate component

### DIFF
--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -4,6 +4,7 @@
 #include "esphome/core/log.h"
 #include "daikin_s21_climate.h"
 #include "../daikin_s21_fan_modes.h"
+#include "../utils.h"
 
 using namespace esphome;
 

--- a/components/daikin_s21/climate/daikin_s21_climate.h
+++ b/components/daikin_s21/climate/daikin_s21_climate.h
@@ -17,7 +17,6 @@ class DaikinS21Climate : public climate::Climate,
   void setup() override;
   void dump_config() override;
   void control(const climate::ClimateCall &call) override;
-  void command_timeout_handler();
   void update_handler();
 
   void set_supported_modes_override(std::set<climate::ClimateMode> modes);
@@ -59,6 +58,7 @@ class DaikinS21Climate : public climate::Climate,
   bool should_check_setpoint();
   void set_s21_climate();
   void set_command_timeout(uint32_t delay_ms = state_publication_timeout_ms);
+  void command_timeout_handler();
 };
 
 } // namespace esphome::daikin_s21

--- a/components/daikin_s21/daikin_s21_fan_modes.h
+++ b/components/daikin_s21/daikin_s21_fan_modes.h
@@ -27,9 +27,6 @@ static constexpr DaikinFanMode supported_daikin_fan_modes[] = {
 
 constexpr std::string_view daikin_fan_mode_to_string_view(const DaikinFanMode mode) {
   switch (mode) {
-    case DaikinFanMode::Auto:
-    default:
-      return "Automatic";
     case DaikinFanMode::Silent:
       return "Silent";
     case DaikinFanMode::Speed1:
@@ -42,6 +39,9 @@ constexpr std::string_view daikin_fan_mode_to_string_view(const DaikinFanMode mo
       return "4";
     case DaikinFanMode::Speed5:
       return "5";
+    case DaikinFanMode::Auto:
+    default:
+      return "Automatic";
   }
 }
 

--- a/components/daikin_s21/daikin_s21_serial.cpp
+++ b/components/daikin_s21/daikin_s21_serial.cpp
@@ -1,0 +1,224 @@
+#include <numeric>
+#include <type_traits>
+#include "esphome/core/application.h"
+#include "daikin_s21_serial.h"
+#include "s21.h"
+#include "utils.h"
+
+namespace esphome::daikin_s21 {
+
+static const char *const TAG = "daikin_s21.serial";
+
+static constexpr uint8_t STX{2};
+static constexpr uint8_t ETX{3};
+static constexpr uint8_t ENQ{5};
+static constexpr uint8_t ACK{6};
+static constexpr uint8_t NAK{21};
+
+void DaikinSerial::setup() {
+  this->uart.set_baud_rate(2400);
+  this->uart.set_stop_bits(2);
+  this->uart.set_data_bits(8);
+  this->uart.set_parity(uart::UART_CONFIG_PARITY_EVEN);
+  this->uart.load_settings();
+  // start idle, wait for updates
+  this->busy = false;
+  this->disable_loop();
+}
+
+/**
+ * Component polling loop
+ *
+ * If the loop is active, we're trying the receive data from the unit.
+ */
+void DaikinSerial::loop() {
+  uint8_t rx_bytes = 0;
+  bool rx_in_progress = true;
+
+  while (rx_in_progress && this->uart.available()) {
+    uint8_t byte;
+    this->uart.read_byte(&byte);
+    rx_bytes++;
+
+    // handle the byte
+    switch (this->comm_state) {
+      case CommState::QueryAck:
+      case CommState::CommandAck:
+        switch (byte) {
+          case ACK:
+            if (this->comm_state == CommState::QueryAck) {
+              this->comm_state = CommState::QueryStx; // query results text to follow
+            } else {
+              this->set_busy_timeout(DaikinSerial::next_tx_delay_period_ms);
+              this->get_parent()->handle_serial_result(Result::Ack);
+              rx_in_progress = false;
+            }
+            break;
+
+          case NAK:
+            this->set_busy_timeout(DaikinSerial::next_tx_delay_period_ms);
+            this->get_parent()->handle_serial_result(Result::Nak);
+            rx_in_progress = false;
+            break;
+
+          default:
+            ESP_LOGW(TAG, "Rx ACK: Unexpected 0x%02" PRIX8, byte);
+            this->set_busy_timeout(DaikinSerial::error_delay_period_ms);
+            this->get_parent()->handle_serial_result(Result::Error);
+            rx_in_progress = false;
+            break;
+        }
+        break;
+
+      case CommState::QueryStx:
+        switch (byte) {
+          case STX:
+            this->comm_state = CommState::QueryEtx; // query results payload to follow
+            break;
+
+          case ACK:
+            ESP_LOGD(TAG, "Rx STX: Repeated ACK, ignoring"); // on rare occasions my unit will do this
+            break;
+
+          default:
+            ESP_LOGW(TAG, "Rx STX: Unexpected 0x%02" PRIX8, byte);
+            this->set_busy_timeout(DaikinSerial::error_delay_period_ms);
+            this->get_parent()->handle_serial_result(Result::Error);
+            rx_in_progress = false;
+        }
+        break;
+
+      case CommState::QueryEtx:
+        switch (byte) {
+          case ETX: // frame received, validate checksum
+            {
+              const uint8_t checksum = this->response.back();
+              this->response.pop_back();
+              const uint8_t calc_checksum = std::reduce(this->response.begin(), this->response.end(), 0U);
+              if ((calc_checksum == checksum) || ((calc_checksum == STX) && (checksum == ENQ))) {  // protocol avoids STX in message body
+                this->set_ack_timeout(rx_bytes);
+                this->get_parent()->handle_serial_result(Result::Ack, this->response);
+                rx_in_progress = false;
+              } else {
+                ESP_LOGW(TAG, "Rx ETX: Checksum mismatch: 0x%02" PRIX8 " != 0x%02" PRIX8 " (calc from %s)",
+                  checksum, calc_checksum, hex_repr(this->response).c_str());
+                this->set_busy_timeout(DaikinSerial::error_delay_period_ms);
+                this->get_parent()->handle_serial_result(Result::Error);
+                rx_in_progress = false;
+              }
+            }
+            break;
+
+          default:  // not the end, add to buffer
+            this->response.push_back(byte);
+            if (this->response.size() > (S21_MAX_COMMAND_SIZE + S21_PAYLOAD_SIZE + 1)) {  // +1 for checksum byte
+              ESP_LOGW(TAG, "Rx ETX: Overflow %s %s + 0x%02" PRIX8,
+                str_repr(this->response).c_str(), hex_repr(this->response).c_str(), byte);
+              this->set_busy_timeout(DaikinSerial::error_delay_period_ms);
+              this->get_parent()->handle_serial_result(Result::Error);
+              rx_in_progress = false;
+            }
+            break;
+        }
+        break;
+
+      default:
+        rx_in_progress = false;
+        break;
+    }
+  }
+
+  // if we received some bytes but still need more, reset the character timeout
+  if (rx_in_progress && (rx_bytes != 0)) {
+    this->set_rx_timeout();
+  }
+}
+
+void DaikinSerial::send_frame(const std::string_view cmd, const std::span<const uint8_t> payload /*= {}*/) {
+  if (this->busy) {
+    return;
+  }
+  this->busy = true;
+
+  if (cmd.size() > S21_MAX_COMMAND_SIZE) {
+    ESP_LOGE(TAG, "Tx: Command '%" PRI_SV "' too large", PRI_SV_ARGS(cmd));
+    this->get_parent()->handle_serial_result(Result::Error);
+    this->set_busy_timeout(DaikinSerial::error_delay_period_ms);  // prevent spam by blocking for a while
+    return;
+  }
+
+  if (this->debug) {
+    if (payload.empty()) {
+      ESP_LOGD(TAG, "Tx: %" PRI_SV, PRI_SV_ARGS(cmd));
+    } else {
+      ESP_LOGD(TAG, "Tx: %" PRI_SV " %s %s",
+               PRI_SV_ARGS(cmd),
+               str_repr(payload).c_str(),
+               hex_repr(payload).c_str());
+    }
+  }
+
+  // clear software and hardware receive buffers
+  this->response.clear();
+  while (this->uart.available()) {
+    uint8_t byte;
+    this->uart.read_byte(&byte);
+  }
+
+  // transmit
+  this->uart.write_byte(STX);
+  this->uart.write_array(reinterpret_cast<const uint8_t *>(cmd.data()), cmd.size());
+  uint8_t checksum = std::reduce(cmd.begin(), cmd.end(), 0U);
+  if (payload.empty() == false) {
+    this->uart.write_array(payload.data(), payload.size());
+    checksum = std::reduce(payload.begin(), payload.end(), checksum);
+  }
+  if (checksum == STX) {
+    checksum = ENQ;  // mid-message STX characters are escaped
+  }
+  this->uart.write_byte(checksum);
+  this->uart.write_byte(ETX);
+
+  // wait for result
+  this->comm_state = payload.empty() ? CommState::QueryAck : CommState::CommandAck;
+  this->set_rx_timeout();
+  this->enable_loop();
+}
+
+void DaikinSerial::set_ack_timeout(const int bytes_received) {
+  // Reduce the delay period by the number of character times waiting for the scheduler
+  // to call loop() since the final ETX was received. This is very minor.
+  auto delay_period_ms = DaikinSerial::ack_delay_period_ms;
+  constexpr uint32_t char_time = 1000 / (2400 / (1+8+2+1));
+  const int max_bytes_per_loop = App.get_loop_interval() / char_time;
+  delay_period_ms -= std::max(max_bytes_per_loop - bytes_received, 0) * char_time;
+
+  this->disable_loop();
+  this->set_timeout(DaikinSerial::timer_name, delay_period_ms, std::bind(&DaikinSerial::ack_timeout_handler, this));
+}
+
+void DaikinSerial::ack_timeout_handler() {
+  this->uart.write_byte(ACK);
+  this->set_timeout(DaikinSerial::timer_name, DaikinSerial::next_tx_delay_period_ms, std::bind(&DaikinSerial::busy_timeout_handler, this));
+}
+
+void DaikinSerial::set_busy_timeout(const uint32_t delay_ms) {
+  this->disable_loop();
+  this->set_timeout(DaikinSerial::timer_name, delay_ms, std::bind(&DaikinSerial::busy_timeout_handler, this));
+}
+
+void DaikinSerial::busy_timeout_handler() {
+  this->busy = false;
+}
+
+void DaikinSerial::set_rx_timeout() {
+  this->set_timeout(DaikinSerial::timer_name, DaikinSerial::rx_timout_period_ms, std::bind(&DaikinSerial::rx_timeout_handler, this));
+}
+
+void DaikinSerial::rx_timeout_handler() {
+  this->busy = false;
+  this->disable_loop();
+  this->get_parent()->handle_serial_result(Result::Timeout);
+}
+
+} // namespace esphome::daikin_s21

--- a/components/daikin_s21/daikin_s21_serial.h
+++ b/components/daikin_s21/daikin_s21_serial.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <cstdint>
+#include <span>
+#include <string_view>
+#include "esphome/components/uart/uart.h"
+#include "esphome/core/component.h"
+
+namespace esphome::daikin_s21 {
+
+class DaikinS21;
+
+class DaikinSerial : public Component,
+                     public Parented<DaikinS21> {
+ public:
+  static constexpr uint32_t S21_MAX_COMMAND_SIZE{4};
+  static constexpr uint32_t S21_PAYLOAD_SIZE{4};
+
+  enum class Result : uint8_t {
+    Ack,
+    Nak,
+    Timeout,
+    Error,
+  };
+
+  DaikinSerial(uart::UARTComponent *uart) : uart(*uart) {}
+
+  void setup() override;
+  void loop() override;
+
+  void set_debug(bool set) { this->debug = set; }
+
+  bool is_busy() const { return this->busy; }
+  void send_frame(std::string_view cmd, std::span<const uint8_t> payload = {});
+
+protected:
+  static constexpr const char * timer_name = "timer";
+  static constexpr uint32_t ack_delay_period_ms{45};      // official remote delay time before ACKing a response
+  static constexpr uint32_t next_tx_delay_period_ms{35};  // official remote delay time between commands
+  static constexpr uint32_t error_delay_period_ms{3000};  // cooldown time when something goes wrong
+  static constexpr uint32_t rx_timout_period_ms{250};   // waiting for a response from the unit
+
+  enum class CommState : uint8_t {
+    CommandAck,
+    QueryAck,
+    QueryStx,
+    QueryEtx,
+  };
+
+  void set_ack_timeout(int bytes_received);
+  void ack_timeout_handler();
+  void set_busy_timeout(uint32_t delay_ms);
+  void busy_timeout_handler();
+  void set_rx_timeout();
+  void rx_timeout_handler();
+
+  uart::UARTComponent &uart;
+  bool debug{};
+  bool busy{};
+  CommState comm_state{};
+  std::vector<uint8_t> response{};
+};
+
+} // namespace esphome::daikin_s21

--- a/components/daikin_s21/utils.cpp
+++ b/components/daikin_s21/utils.cpp
@@ -1,0 +1,47 @@
+#include "esphome/core/helpers.h"
+#include "utils.h"
+
+namespace esphome::daikin_s21 {
+
+std::string hex_repr(std::span<const uint8_t> bytes) {
+  return format_hex_pretty(bytes.data(), bytes.size(), ':', false);
+}
+
+// Adapated from ESPHome UART debugger
+std::string str_repr(std::span<const uint8_t> bytes) {
+  std::string res;
+  char buf[5];
+  for (const auto b : bytes) {
+    if (b == 7) {
+      res += "\\a";
+    } else if (b == 8) {
+      res += "\\b";
+    } else if (b == 9) {
+      res += "\\t";
+    } else if (b == 10) {
+      res += "\\n";
+    } else if (b == 11) {
+      res += "\\v";
+    } else if (b == 12) {
+      res += "\\f";
+    } else if (b == 13) {
+      res += "\\r";
+    } else if (b == 27) {
+      res += "\\e";
+    } else if (b == 34) {
+      res += "\\\"";
+    } else if (b == 39) {
+      res += "\\'";
+    } else if (b == 92) {
+      res += "\\\\";
+    } else if (b < 32 || b > 127) {
+      sprintf(buf, "\\x%02" PRIX8, b);
+      res += buf;
+    } else {
+      res += b;
+    }
+  }
+  return res;
+}
+
+} // namespace esphome::daikin_s21

--- a/components/daikin_s21/utils.h
+++ b/components/daikin_s21/utils.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <span>
+
+namespace esphome::daikin_s21 {
+
+// printf format specifier macros for std::string_view
+#define PRI_SV ".*s"
+#define PRI_SV_ARGS(x) (x).size(), (x).data()
+
+std::string hex_repr(std::span<const uint8_t> bytes);
+std::string str_repr(std::span<const uint8_t> bytes);
+
+} // namespace esphome::daikin_s21


### PR DESCRIPTION
- Make serial state machine delays timer driven. Saves ~300ms on a query cycle.
- Construct DaikinS21Serial with UARTDevice, no knowledge at DaikinS21 level
- Move debug communication debug configuration direct to DaikinS21Serial
- Reduce sizes of DaikinSerial Result and CommState enums
- Add utils.h/utils.cpp to share debugging function implementations
- Change protocol version to enum
- Move default switch cases to bottom of statements
- Make serial response buffer protected