### PR TITLE
Track queries in progress and use specific callbacks

### DIFF
--- a/components/daikin_s21/s21.cpp
+++ b/components/daikin_s21/s21.cpp
@@ -1,5 +1,6 @@
 #include <cinttypes>
 #include <numeric>
+#include <ranges>
 #include "s21.h"
 #include "utils.h"
 
@@ -127,44 +128,60 @@ int16_t bytes_to_num(std::span<const uint8_t> bytes) {
 void DaikinS21::setup() {
   // populate initial messages to poll
   // clang-format off
-  queries = {
+  this->queries = {
       // Protocol version detect
-      StateQuery::OldProtocol,
-      StateQuery::NewProtocol,
-      StateQuery::ModelCode,
-      MiscQuery::Model,
-      MiscQuery::Version,
+      {StateQuery::OldProtocol, &DaikinS21::handle_nop, true},
+      {StateQuery::NewProtocol, &DaikinS21::handle_nop, true},
+      {StateQuery::ModelCode, &DaikinS21::handle_nop, true},
+      {MiscQuery::Model, &DaikinS21::handle_nop, true}, // some sort of model? always "3E53" for me, regardless of head unit
+      {MiscQuery::Version, &DaikinS21::handle_nop, true}, // purportedly another version, always "00C0" for me
       // Basic sensor support
-      StateQuery::InsideOutsideTemperatures,
-      EnvironmentQuery::InsideTemperature,
-      EnvironmentQuery::LiquidTemperature,
-      EnvironmentQuery::FanSpeed,
-      EnvironmentQuery::OutsideTemperature,
+      {StateQuery::InsideOutsideTemperatures, &DaikinS21::handle_state_inside_outside_temperature},
+      {EnvironmentQuery::InsideTemperature, &DaikinS21::handle_env_inside_temperature},
+      {EnvironmentQuery::LiquidTemperature, &DaikinS21::handle_env_liquid_temperature},
+      {EnvironmentQuery::FanSpeed, &DaikinS21::handle_env_fan_speed},
+      {EnvironmentQuery::OutsideTemperature, &DaikinS21::handle_env_outside_temperature},
       // Standard
-      StateQuery::Basic,
-      StateQuery::OptionalFeatures,
-      StateQuery::SwingOrHumidity,
-      StateQuery::SpecialModes,
-      StateQuery::DemandAndEcono,
-      EnvironmentQuery::FanMode,
-      EnvironmentQuery::TargetTemperature,
-      EnvironmentQuery::IndoorFrequencyCommandSignal,
-      EnvironmentQuery::CompressorFrequency,
+      {StateQuery::Basic, &DaikinS21::handle_state_basic},
+      {StateQuery::OptionalFeatures, &DaikinS21::handle_state_optional_features, true},
+      {StateQuery::SwingOrHumidity, &DaikinS21::handle_state_swing_or_humidity},
+      {StateQuery::SpecialModes, &DaikinS21::handle_state_special_modes},
+      {StateQuery::DemandAndEcono, &DaikinS21::handle_state_demand_and_econo},
+      {EnvironmentQuery::FanMode, &DaikinS21::handle_env_fan_mode},
+      {EnvironmentQuery::TargetTemperature, &DaikinS21::handle_env_target_temperature},
+      {EnvironmentQuery::IndoorFrequencyCommandSignal, &DaikinS21::handle_env_indoor_frequency_command_signal},
+      {EnvironmentQuery::CompressorFrequency, &DaikinS21::handle_env_compressor_frequency},
       // State
-      EnvironmentQuery::UnitState,
-      EnvironmentQuery::SystemState,
+      {EnvironmentQuery::UnitState, &DaikinS21::handle_env_unit_state},
+      {EnvironmentQuery::SystemState, &DaikinS21::handle_env_system_state},
       // Redundant
-      // EnvironmentQuery::PowerOnOff,
-      // EnvironmentQuery::IndoorUnitMode,
-      // EnvironmentQuery::TemperatureSetPoint,
+      // {EnvironmentQuery::PowerOnOff, &DaikinS21::handle_env_power_on_off},
+      // {EnvironmentQuery::IndoorUnitMode, &DaikinS21::handle_env_indoor_unit_mode},
+      // {EnvironmentQuery::TemperatureSetPoint, &DaikinS21::handle_env_temperature_setpoint},
+      // {EnvironmentQuery::SwingMode, &DaikinS21::handle_env_swing_mode},
+      // {EnvironmentQuery::FanMode, &DaikinS21::handle_env_fan_mode},
       // Unused
-      // StateQuery::OnOffTimer,  // use home assistant for scheduling
+      // {StateQuery::OnOffTimer},  // use home assistant for scheduling
       // Not handled yet
-      // StateQuery::ErrorStatus,
-      // StateQuery::FanSetPoint,
-      // StateQuery::LouvreAngleSetPoint,
+      // {StateQuery::ErrorStatus},
+      // {StateQuery::FanSetPoint},
+      // {StateQuery::LouvreAngleSetPoint},
   };
   // clang-format on
+  this->failed_queries = {};
+  this->static_queries = {};
+  this->comms_detected = false;
+  this->start_poller();
+  this->disable_loop();
+}
+
+/**
+ * Component update loop.
+ *
+ * Used for deferred work. Printing too much in the timer callback context causes warnings about blocking for too long.
+ */
+void DaikinS21::loop() {
+  this->dump_state(); // use Component::defer if more work items are added
   this->disable_loop();
 }
 
@@ -243,19 +260,51 @@ void DaikinS21::start_cycle() {
   this->cycle_triggered = this->is_free_run();
   this->cycle_time_start_ms = millis();
   this->current_query = queries.begin();
-  this->tx_command = *(this->current_query);
-  this->serial.send_frame(this->tx_command);
+  this->serial.send_frame(this->current_query->command);
+}
+
+/**
+ * Check if a query is in the active pool and has been acked
+ */
+bool DaikinS21::is_query_active(std::string_view query_str) const {
+  const auto query = std::ranges::find(this->queries, query_str, DaikinQueryState::GetCommand);
+  return (query != this->queries.end()) && query->acked;
+}
+
+/**
+ * Check if a query is in the unsupported pool (i.e. has been NAK'd)
+ */
+bool DaikinS21::is_query_unsupported(std::string_view query_str) const {
+  return std::ranges::find(this->failed_queries, query_str) != this->failed_queries.end();
+}
+
+/**
+ * Get a pointer to the results of a static query
+ *
+ * @return pointer to result buffer, nullptr if not resolved (yet)
+ */
+const PayloadBuffer* DaikinS21::get_static_query(std::string_view query_str) const {
+  const auto iter = std::ranges::find(this->static_queries, query_str, DaikinQueryState::GetCommand);
+  if (iter != this->static_queries.end()) {
+    return &(iter->value);
+  } else {
+    return nullptr;
+  }
 }
 
 /**
  * Remove a query from the active pool.
  *
- * @note Does not rewrite the query iterator. Should only be called at the end of a query cycle.
+ * Fixes up the current_query iterator.
  */
-void DaikinS21::prune_query(std::string_view query) {
-  const auto it = std::ranges::find(this->queries, query);
-  if (it != this->queries.end()) {
-    this->queries.erase(it);
+void DaikinS21::prune_query(std::string_view query_str) {
+  const auto query = std::ranges::find(this->queries, query_str, DaikinQueryState::GetCommand);
+  if (query != this->queries.end()) {
+    // current_query iterator will be invalidated, recover index and recreate
+    const auto query_index = std::distance(this->queries.begin(), query);
+    const auto current_index = std::distance(this->queries.begin(), this->current_query);
+    this->queries.erase(query);
+    this->current_query = this->queries.begin() + current_index + ((current_index > query_index) ? -1 : 0);  // adjust index for the hole
   }
 }
 
@@ -263,40 +312,29 @@ void DaikinS21::prune_query(std::string_view query) {
  * Refine the pool of polling queries, adding or removing them as we learn about the unit.
  */
 void DaikinS21::refine_queries() {
-  if (this->ready.all() == false) {
-    if (this->ready[ReadyProtocolVersion] == false) {
-      if (this->determine_protocol_version()) {
-        this->prune_query(StateQuery::OldProtocol);
-        this->prune_query(StateQuery::ModelCode);
-        this->prune_query(StateQuery::NewProtocol);
-        this->prune_query(MiscQuery::Model);
-        this->prune_query(MiscQuery::Version);
-        ESP_LOGI(TAG, "Protocol version %" PRI_SV " detected", PRI_SV_ARGS(protocol_to_string(this->protocol_version)));
-        this->ready.set(ReadyProtocolVersion);
-      }
-    }
-    // Some units don't support more granular sensor queries
-    if (this->ready[ReadySensorReadout] == false) {
-      // TODO there's a chance that communication doesn't work at all so we didn't receive a NAK and these are still active. add an "acked" tracker to the queries if this is a concern.
-      if (this->is_query_active(EnvironmentQuery::InsideTemperature) && this->is_query_active(EnvironmentQuery::OutsideTemperature)) {
-        this->prune_query(StateQuery::InsideOutsideTemperatures);  // support for discrete granular sensors, no need for inferior consolidated query
-      }
-      this->ready.set(ReadySensorReadout);
-    }
-    if (this->ready[ReadyCapabilities] == false) {
-      if (this->detect_responses.G2_model_info != 0) {
-        this->prune_query(StateQuery::OptionalFeatures);
-        if (this->support_swing) {
-          this->queries.emplace_back(EnvironmentQuery::VerticalSwingAngle);
-        }
-        if (this->support_humidity) {
-          this->queries.emplace_back(EnvironmentQuery::IndoorHumidity);
-        }
-        ESP_LOGI(TAG, "Capabilities detected: model info %c", this->detect_responses.G2_model_info);
-        this->ready.set(ReadyCapabilities);
-      }
+  if (this->protocol_version == ProtocolUndetected) {
+    if (this->determine_protocol_version()) {
+      ESP_LOGI(TAG, "Protocol version %" PRI_SV " detected", PRI_SV_ARGS(protocol_to_string(this->protocol_version)));
     }
   }
+  if (this->ready.all() == false) {
+    // Some units don't support more granular sensor queries
+    if (this->ready[ReadySensorReadout] == false) {
+      this->support_inside_temperature = this->is_query_active(EnvironmentQuery::InsideTemperature);
+      this->support_outside_temperature = this->is_query_active(EnvironmentQuery::OutsideTemperature);
+      if (this->support_inside_temperature && this->support_outside_temperature) {
+        this->prune_query(StateQuery::InsideOutsideTemperatures);  // support for discrete granular sensors, no need for inferior consolidated query
+      }
+      // done if both queries have been resolved
+      this->ready[ReadySensorReadout] = (this->support_inside_temperature || this->is_query_unsupported(EnvironmentQuery::InsideTemperature))
+                                     && (this->support_outside_temperature || this->is_query_unsupported(EnvironmentQuery::OutsideTemperature));
+    }
+  }
+}
+
+void DaikinS21::send_command(std::string_view command, std::span<const uint8_t> payload) {
+  this->current_command = command;
+  this->serial.send_frame(this->current_command, payload);
 }
 
 /**
@@ -309,29 +347,27 @@ void DaikinS21::refine_queries() {
  * - Start the next cycle if free running or triggered in polling mode
  */
 void DaikinS21::handle_serial_idle() {
-  std::array<uint8_t, DaikinSerial::S21_PAYLOAD_SIZE> payload;
+  PayloadBuffer payload;
 
   // Apply any pending settings
   // Important to clear the activate flag here as another command can be queued while waiting for this one to complete
   if (this->activate_climate) {
     this->activate_climate = false;
-    this->tx_command = StateCommand::PowerModeTempFan;
     payload[0] = (this->pending.mode == climate::CLIMATE_MODE_OFF) ? '0' : '1'; // power
     payload[1] = climate_mode_to_daikin(this->pending.mode);
     payload[2] = (static_cast<int16_t>(this->pending.setpoint) / 5) + 28;
     payload[3] = static_cast<char>(this->pending.fan);
-    this->serial.send_frame(this->tx_command, payload);
+    this->send_command(StateCommand::PowerModeTempFan, payload);
     return;
   }
 
   if (activate_swing_mode) {
     this->activate_swing_mode = false;
-    this->tx_command = StateCommand::LouvreSwing;
     payload[0] = climate_swing_mode_to_daikin(this->pending.swing);
     payload[1] = (this->pending.swing != climate::CLIMATE_SWING_OFF) ? '?' : '0';
     payload[2] = '0';
     payload[3] = '0';
-    this->serial.send_frame(this->tx_command, payload);
+    this->send_command(StateCommand::LouvreSwing, payload);
     return;
   }
 
@@ -352,20 +388,18 @@ void DaikinS21::handle_serial_idle() {
     }
     switch (preset) {
       case climate::CLIMATE_PRESET_BOOST:
-        this->tx_command = StateCommand::Powerful;
         payload[0] = enable ? '2' : '0';
         payload[1] = '0';
         payload[2] = '0';
         payload[3] = '0';
-        this->serial.send_frame(this->tx_command, payload);
+        this->send_command(StateCommand::Powerful, payload);
         return;
       case climate::CLIMATE_PRESET_ECO:
-        this->tx_command = StateCommand::Econo;
         payload[0] = '0';
         payload[1] = enable ? '2' : '0';
         payload[2] = '0';
         payload[3] = '0';
-        this->serial.send_frame(this->tx_command, payload);
+        this->send_command(StateCommand::Econo, payload);
         return;
       case climate::CLIMATE_PRESET_NONE:
       default:
@@ -375,8 +409,7 @@ void DaikinS21::handle_serial_idle() {
 
   // Periodic query cycle
   if (this->current_query != this->queries.end()) {
-    this->tx_command = *current_query;  // query cycle underway, continue
-    this->serial.send_frame(this->tx_command);
+    this->serial.send_frame(this->current_query->command);  // query cycle underway, continue
     return;
   }
 
@@ -404,9 +437,9 @@ void DaikinS21::handle_serial_idle() {
     }
   }
 
-  if ((now - last_state_dump_ms) > (60 * 1000)) {
+  if ((now - last_state_dump_ms) > (60 * 1000)) { // every minute
     last_state_dump_ms = now;
-    this->dump_state();
+    this->enable_loop();  // dump state in foreground, blocks for too long here
   }
 
   // Start fresh polling query cycle (triggered never cleared in free run)
@@ -415,198 +448,140 @@ void DaikinS21::handle_serial_idle() {
   }
 }
 
-static DaikinC10 temp_bytes_to_c10(std::span<const uint8_t> bytes) { return bytes_to_num(bytes); }
-static constexpr DaikinC10 temp_f9_byte_to_c10(uint8_t byte) { return (byte - 128) * 5; }
-static constexpr uint8_t ahex_digit(uint8_t digit) { return (digit >= 'A') ? (digit - 'A') + 10 : digit - '0'; }
-static constexpr uint8_t ahex_u8_le(uint8_t first, uint8_t second) { return (ahex_digit(second) << 4) | ahex_digit(first); }
-
-void DaikinS21::parse_ack(const std::span<const uint8_t> response) {
-  std::span<const uint8_t> rcode{};
-  std::span<const uint8_t> payload{};
-
-  ESP_LOGV(TAG, "ACK from S21 for %" PRI_SV, PRI_SV_ARGS(this->tx_command));
-
-  // prepare response buffers for decoding
-  if (response.empty()) {
-    // commands don't return anything except an Ack, pretend we received the command itself to provide something to distinguish handling below
-    rcode = { reinterpret_cast<const uint8_t *>(this->tx_command.data()), this->tx_command.size() };
+void DaikinS21::handle_state_basic(const std::span<const uint8_t> payload) {
+  if (payload[0] == '0') {
+    this->active.mode = climate::CLIMATE_MODE_OFF;
+    this->action_reported = climate::CLIMATE_ACTION_OFF;
   } else {
-    rcode = { response.begin(), this->tx_command.size() };
-    payload = { response.begin() + rcode.size(), response.end() };
+    this->active.mode = daikin_to_climate_mode(payload[1]);
+    this->action_reported = daikin_to_climate_action(payload[1]);
   }
+  this->active.setpoint = (payload[2] - 28) * 5;  // Celsius * 10
+  // fan mode in payload[3], silent mode not reported so prefer RG
+  this->ready.set(ReadyBasic);
+}
 
-  switch (rcode[0]) {
-    case 'D':  // D -> D (command fake response, see above)
-      switch (rcode[1]) {
-        case '1': break; // climate setting applied
-        case '5': break; // swing settings applied
-        case '6': break; // powerful setting applied
-        case '7': break; // econo setting applied
-        default: break;
-      }
-      return;
-
-    case 'G':  // F -> G
-      switch (rcode[1]) {
-        case '1':  // F1 -> G1 Basic State
-          if (payload[0] == '0') {
-            this->active.mode = climate::CLIMATE_MODE_OFF;
-            this->action_reported = climate::CLIMATE_ACTION_OFF;
-          } else {
-            this->active.mode = daikin_to_climate_mode(payload[1]);
-            this->action_reported = daikin_to_climate_action(payload[1]);
-          }
-          this->active.setpoint = (payload[2] - 28) * 5;  // Celsius * 10
-          // fan mode in payload[3], silent mode not reported so prefer RG
-          this->ready.set(ReadyBasic);
-          return;
-        case '2':
-          this->support_swing = payload[0] & 0b0100;
-          this->support_horizontal_swing = payload[0] & 0b1000;
-          this->detect_responses.G2_model_info = (payload[1] & 0b1000) ? 'N': 'C';
-          this->support_humidity = payload[3] & 0b0010;
-          return;
-        case '5':  // F5 -> G5 -- Swing state
-          this->active.swing = daikin_to_climate_swing_mode(payload[0]);
-          return;
-        case '6':
-          this->modifiers[ModifierPowerful] = (payload[0] & 0b00000010);
-          this->modifiers[ModifierComfort] =  (payload[0] & 0b01000000);
-          this->modifiers[ModifierQuiet] =    (payload[0] & 0b10000000);
-          this->modifiers[ModifierStreamer] = (payload[1] & 0b10000000);
-          this->modifiers[ModifierSensor] =   (payload[3] & 0b00001000);
-          this->modifiers[ModifierLED] =      (payload[3] & 0b00001100) == 0b00001100;
-          return;
-        case '7':
-          this->modifiers[ModifierEcono] =    (payload[1] == '2');
-          return;
-        case '8':  // F8 -> G8 -- Original protocol version
-          std::copy_n(payload.begin(), std::min(payload.size(), this->detect_responses.G8.size()), this->detect_responses.G8.begin());
-          return;
-        case '9':  // F9 -> G9 -- Temperature and humidity, better granularity in RH, Ra and Re
-          this->temp_inside = temp_f9_byte_to_c10(payload[0]);  // 1 degree
-          this->temp_outside = temp_f9_byte_to_c10(payload[1]); // 1 degree, danijelt reports 0xFF when unsupported
-          if ((payload[2] - '0') <= 100) {  // Some units report 0xFF when unsupported
-            this->humidity = payload[2] - '0';  // 5% granularity
-          }
-          return;
-        case 'C':  // FC -> GC -- Model code (hex, not reversed here)
-          std::copy_n(payload.begin(), std::min(payload.size(), this->detect_responses.GC.size()), this->detect_responses.GC.begin());
-          return;
-        case 'Y':
-          if ((rcode[2] == '0') && (rcode[3] == '0')) { // FY00 -> GY00 Newer protocol version
-            this->detect_responses.GY00 = bytes_to_num(payload);
-          }
-          return;
-        default:
-          break;
-      }
-      break;
-
-    case 'S':  // R -> S
-      switch (rcode[1]) {
-        case 'B':  // Operational mode, single character, same info as G1
-          return;
-        case 'C':  // Setpoint, same info as G1
-          this->active.setpoint = bytes_to_num(payload) * 10;  // whole degrees C
-          return;
-        case 'F':  // Swing mode, same info as G5. ascii hex string: 2F herizontal 1F vertical 7F both 00 off
-          return;
-        case 'G':  // Fan mode, better detail than G1 (reports quiet mode)
-          this->active.fan = static_cast<daikin_s21::DaikinFanMode>(payload[0]);
-          return;
-        case 'H':  // Inside temperature
-          this->temp_inside = temp_bytes_to_c10(payload);
-          return;
-        case 'I':  // Coil temperature
-          this->temp_coil = temp_bytes_to_c10(payload);
-          return;
-        case 'L':  // Fan speed
-          this->fan_rpm = bytes_to_num(payload) * 10;
-          return;
-        case 'M':  // v_swing setpoint
-          break;
-        case 'N':  // Vertical swing angle
-          this->swing_vertical_angle = bytes_to_num(payload);
-          return;
-        case 'X':  // Internal control loop target temperature
-          this->temp_target = temp_bytes_to_c10(payload);
-          return;
-        case 'a':  // Outside temperature
-          this->temp_outside = temp_bytes_to_c10(payload);
-          return;
-        case 'b':  // Demand, 0-15
-          this->demand = bytes_to_num(payload) / 10;
-          return;
-        case 'd':  // Compressor frequency in hertz, idle if 0.
-          this->compressor_hz = bytes_to_num(payload);
-          if (this->compressor_hz == 999) {
-            this->compressor_hz = 0;  // reported by danijelt
-          }
-          return;
-        case 'e':  // Humidity, %
-          this->humidity = bytes_to_num(payload);
-          return;
-        case 'z':
-          if ((rcode[2] == 'B') && (rcode[3] == '2')) { // FzB2 -> GzB2 Unit state
-            this->unit_state = ahex_digit(payload[0]);
-            this->modifiers[ModifierPowerful] = this->unit_state.powerful();  // if G6 is unsupported we can still read out powerful set by remote
-          }
-          else if ((rcode[2] == 'C') && (rcode[3] == '3')) { // FzC3 -> GzC3 System state
-            this->system_state = ahex_u8_le(payload[0], payload[1]);
-          }
-          return;
-        default:
-          if (payload.size() > 3) {
-            auto temp = temp_bytes_to_c10(payload);
-            ESP_LOGD(TAG, "Unknown sensor: %" PRI_SV " -> %s -> %.1f C (%.1f F)",
-                     PRI_SV_ARGS(rcode),
-                     hex_repr(payload).c_str(),
-                     temp.f_degc(), temp.f_degf());
-          }
-          break;
-      }
-      break;
-
-    case 'M':  // some sort of model? always "3E53" for me, regardless of head unit
-      std::copy_n(payload.begin(), std::min(payload.size(), this->detect_responses.M.size()), this->detect_responses.M.begin());
-      return;
-
-    case 'V':  // purportedly another version, always "00C0" for me
-      std::copy_n(payload.begin(), std::min(payload.size(), this->detect_responses.V.size()), this->detect_responses.V.begin());
-      return;
-
-    default:
-      break;
+void DaikinS21::handle_state_optional_features(const std::span<const uint8_t> payload) {
+  if (payload[0] & 0b0100) {
+    this->support_swing = true;
+    this->queries.emplace_back(EnvironmentQuery::VerticalSwingAngle, &DaikinS21::handle_env_vertical_swing_angle);
   }
-
-  // protocol decoding debug
-  // note: well known responses return directly from the switch statements
-  // break instead if you want to view their contents down here
-
-  // print everything
-  if (this->debug) {
-    ESP_LOGD(TAG, "S21: %" PRI_SV " -> %s %s",
-             PRI_SV_ARGS(rcode),
-             str_repr(payload).c_str(),
-             hex_repr(payload).c_str());
+  this->support_horizontal_swing = payload[0] & 0b1000;
+  // todo climate traits config check
+  this->G2_model_info = (payload[1] & 0b1000) ? 'N': 'C';
+  ESP_LOGI(TAG, "Capabilities detected: model info %c", this->G2_model_info);
+  if (payload[3] & 0b0010) {
+    this->support_humidity = true;
+    this->queries.emplace_back(EnvironmentQuery::IndoorHumidity, &DaikinS21::handle_env_indoor_humidity);
   }
+}
 
-  // print changed values
-  if (this->debug) {
-    std::string key(rcode.begin(), rcode.end());
-    auto curr = std::vector<uint8_t>(payload.begin(), payload.end());
-    if (val_cache[key] != curr) {
-      const auto prev = val_cache[key];
-      ESP_LOGI(TAG, "S21 %s changed: %s %s -> %s %s",
-               key.c_str(),
-               str_repr(prev).c_str(),
-               hex_repr(prev).c_str(),
-               str_repr(curr).c_str(),
-               hex_repr(curr).c_str());
-      val_cache[key] = curr;
-    }
+void DaikinS21::handle_state_swing_or_humidity(const std::span<const uint8_t> payload) {
+  this->active.swing = daikin_to_climate_swing_mode(payload[0]);
+}
+
+void DaikinS21::handle_state_special_modes(const std::span<const uint8_t> payload) {
+  this->modifiers[ModifierPowerful] = (payload[0] & 0b00000010);
+  this->modifiers[ModifierComfort] =  (payload[0] & 0b01000000);
+  this->modifiers[ModifierQuiet] =    (payload[0] & 0b10000000);
+  this->modifiers[ModifierStreamer] = (payload[1] & 0b10000000);
+  this->modifiers[ModifierSensor] =   (payload[3] & 0b00001000);
+  this->modifiers[ModifierLED] =      (payload[3] & 0b00001100) == 0b00001100;
+}
+
+void DaikinS21::handle_state_demand_and_econo(const std::span<const uint8_t> payload) {
+  this->modifiers[ModifierEcono] =    (payload[1] == '2');
+}
+
+void DaikinS21::handle_state_inside_outside_temperature(const std::span<const uint8_t> payload) {
+  if (this->support_inside_temperature == false) {  // more granular in EnvironmentQuery::InsideTemperature
+    this->temp_inside = (payload[0] - 128) * 5;  // 1 degree
   }
+  if (this->support_outside_temperature == false) { // more granular in EnvironmentQuery::OutsideTemperature
+    this->temp_outside = (payload[1] - 128) * 5; // 1 degree, danijelt reports 0xFF when unsupported
+  }
+  if ((payload[2] - '0') <= 100) {  // Some units report 0xFF when unsupported
+    this->humidity = payload[2] - '0';  // 5% granularity
+  }
+}
+
+/** Vastly inferior to StateQuery::Basic */
+void DaikinS21::handle_env_power_on_off(std::span<const uint8_t> payload) {
+  const bool active = payload[0] == '1';
+}
+
+/** Same info as StateQuery::Basic */
+void DaikinS21::handle_env_indoor_unit_mode(const std::span<const uint8_t> payload) {
+  if (payload[0] == '0') {
+    this->active.mode = climate::CLIMATE_MODE_OFF;
+    this->action_reported = climate::CLIMATE_ACTION_OFF;
+  } else {
+    this->active.mode = daikin_to_climate_mode(payload[1]);
+    this->action_reported = daikin_to_climate_action(payload[1]);
+  }
+}
+
+/** Same info as StateQuery::Basic */
+void DaikinS21::handle_env_temperature_setpoint(const std::span<const uint8_t> payload) {
+  this->active.setpoint = bytes_to_num(payload) * 10;  // whole degrees C
+}
+
+/** Same info as StateQuery::SwingOrHumidity */
+void DaikinS21::handle_env_swing_mode(const std::span<const uint8_t> payload) {
+  this->active.swing = daikin_to_climate_swing_mode(payload[0]);
+}
+
+/** Better info than StateQuery::Basic (reports quiet) */
+void DaikinS21::handle_env_fan_mode(const std::span<const uint8_t> payload) {
+  this->active.fan = static_cast<daikin_s21::DaikinFanMode>(payload[0]);
+}
+
+void DaikinS21::handle_env_inside_temperature(const std::span<const uint8_t> payload) {
+  this->temp_inside = bytes_to_num(payload);
+}
+
+void DaikinS21::handle_env_liquid_temperature(const std::span<const uint8_t> payload) {
+  this->temp_coil = bytes_to_num(payload);
+}
+
+void DaikinS21::handle_env_fan_speed(const std::span<const uint8_t> payload) {
+  this->fan_rpm = bytes_to_num(payload) * 10;
+}
+
+void DaikinS21::handle_env_vertical_swing_angle(const std::span<const uint8_t> payload) {
+  this->swing_vertical_angle = bytes_to_num(payload);
+}
+
+void DaikinS21::handle_env_target_temperature(const std::span<const uint8_t> payload) {
+  this->temp_target = bytes_to_num(payload); // Internal control loop target temperature
+}
+
+void DaikinS21::handle_env_outside_temperature(const std::span<const uint8_t> payload) {
+  this->temp_outside = bytes_to_num(payload);
+}
+
+void DaikinS21::handle_env_indoor_frequency_command_signal(const std::span<const uint8_t> payload) {
+  this->demand = bytes_to_num(payload) / 10;  // Demand, 0-15
+}
+
+void DaikinS21::handle_env_compressor_frequency(const std::span<const uint8_t> payload) {
+  this->compressor_hz = bytes_to_num(payload);
+  if (this->compressor_hz == 999) {
+    this->compressor_hz = 0;  // reported by danijelt
+  }
+}
+
+void DaikinS21::handle_env_indoor_humidity(const std::span<const uint8_t> payload) {
+  this->humidity = bytes_to_num(payload);
+}
+
+void DaikinS21::handle_env_unit_state(const std::span<const uint8_t> payload) {
+  this->unit_state = ahex_digit(payload[0]);
+  this->modifiers[ModifierPowerful] = this->unit_state.powerful();  // if G6 is unsupported we can still read out powerful set by remote
+}
+
+void DaikinS21::handle_env_system_state(const std::span<const uint8_t> payload) {
+  this->system_state = ahex_u8_le(payload[0], payload[1]);
 }
 
 /**
@@ -618,95 +593,207 @@ void DaikinS21::parse_ack(const std::span<const uint8_t> response) {
  * @return false protocol version wasn't detected
  */
 bool DaikinS21::determine_protocol_version() {
-  static constexpr uint8_t G8_version0[4] = {'0',0,0,0};
-  static constexpr uint8_t G8_version2or3[4] = {'0','2',0,0};
-  static constexpr uint8_t G8_version31plus[4] = {'0','2','0','0'};
+  static constexpr uint8_t old_version_0[4] = {'0',0,0,0};
+  static constexpr uint8_t old_version_2or3[4] = {'0','2',0,0};
+  static constexpr uint8_t old_version_31plus[4] = {'0','2','0','0'};
+  static constexpr uint8_t new_version_300[4] = {'0','0','3','0'};
+  static constexpr uint8_t new_version_320[4] = {'0','2','3','0'};
+  static constexpr uint8_t new_version_340[4] = {'0','4','3','0'};
 
-  if (std::ranges::equal(this->detect_responses.G8, G8_version0)) {
-    this->protocol_version = Protocol0;
-    return true;
-  }
+  // both protocol indicators should have been resolved if we're in here
+  const auto old_proto = this->get_static_query(StateQuery::OldProtocol);
+  const bool old_failed = this->is_query_unsupported(StateQuery::OldProtocol);
+  const auto new_proto = this->get_static_query(StateQuery::NewProtocol);
+  const bool new_failed = this->is_query_unsupported(StateQuery::NewProtocol);
 
-  if ((is_query_active(StateQuery::NewProtocol) == false)) {
-    if (std::ranges::equal(this->detect_responses.G8, G8_version2or3) || std::ranges::equal(this->detect_responses.G8, G8_version31plus)) {
-      this->protocol_version = Protocol2;  // NAK for NewProtocol rules out 3.0
-      return true;
+  // Check availability first
+  if (old_proto && new_failed) {
+    if (std::ranges::equal(*old_proto, old_version_0)) {
+      this->protocol_version = Protocol0;
+    } else if (std::ranges::equal(*old_proto, old_version_2or3)
+            || std::ranges::equal(*old_proto, old_version_31plus)) {
+      this->protocol_version = Protocol2; // NAK for NewProtocol rules out 3.0
+    } else {
+      this->protocol_version = ProtocolUnknown;
     }
+  } else if ((old_proto || old_failed) && new_proto) {
+    if (std::ranges::equal(*new_proto, new_version_300)) {
+      if (old_failed) {
+        this->protocol_version = ProtocolUnknown; // Need old protocol to make the distinction
+      } else if (std::ranges::equal(*old_proto, old_version_2or3)) {
+        this->protocol_version = Protocol3_0; // ACK for NewProtocol means 3.0 has support for this query
+      } else if (std::ranges::equal(*old_proto, old_version_31plus)) {
+        this->protocol_version = Protocol3_1;
+      } else {
+        this->protocol_version = ProtocolUnknown;
+      }
+    } else if (std::ranges::equal(*new_proto, new_version_320)) {
+      this->protocol_version = Protocol3_2;
+    } else if (std::ranges::equal(*new_proto, new_version_340)) {
+      this->protocol_version = Protocol3_4;
+    } else {
+      this->protocol_version = ProtocolUnknown;
+    }
+  } else if (old_failed && new_failed) {
+    // both nak'd, even though we're talking to the unit
+    ESP_LOGE(TAG, "Unable to detect a protocol version!");
+    this->protocol_version = ProtocolUnknown;
   } else {
-    switch (this->detect_responses.GY00) {
-      case 300:
-        if (std::ranges::equal(this->detect_responses.G8, G8_version2or3)) {
-          this->protocol_version = Protocol3_0;  // ACK for NewProtocol means 3.0 has support for this query
-          return true;
-        }
-        if (std::ranges::equal(this->detect_responses.G8, G8_version31plus)) {
-          this->protocol_version = Protocol3_1;
-          return true;
-        }
-        break;
-      case 320:
-        this->protocol_version = Protocol3_2;
-        return true;
-      case 340:
-        this->protocol_version = Protocol3_4;
-        return true;
-      default:
-        break;
-    }
+    ESP_LOGV(TAG, "Protocol version not ready yet");
   }
-  ESP_LOGE(TAG, "Unable to detect a protocol version, will not function: %s, %d", str_repr(this->detect_responses.G8).c_str(), this->detect_responses.GY00);
-  return false; // not detected yet or unsupported
+
+  // Print some info if we're falling back to version 0
+  if (this->protocol_version == ProtocolUnknown) {
+    ESP_LOGE(TAG, "Unable to detect protocol version! Old: %s New: %s",
+      old_proto ? str_repr(*old_proto).c_str() : "NAK",
+      new_proto ? str_repr(*new_proto).c_str() : "NAK");
+  }
+
+  return this->protocol_version != daikin_s21::ProtocolUndetected;
 }
 
 void DaikinS21::handle_serial_result(const DaikinSerial::Result result, const std::span<const uint8_t> response /*= {}*/) {
+  const bool is_query = this->current_command.empty();
+  const std::string_view &tx_str = is_query ? this->current_query->command : this->current_command;
+  std::span<const uint8_t> payload = { response.begin() + tx_str.size(), response.end() };
+
+  // add commands to this array to debug their output. empty string is just a placeholder to compile
+  static constexpr std::array debug_commands{""};
+  const bool is_debug = this->debug && (std::ranges::find(debug_commands, tx_str) != debug_commands.end());
+
+  // debug logging
   switch (result) {
     case DaikinSerial::Result::Ack:
-      this->parse_ack(response);
-      if (this->tx_command == *(this->current_query)) {
-        this->current_query++;
+      if (//this->debug ||  // uncomment to debug all, not just debug_commands
+          is_debug) {
+        ESP_LOGD(TAG, "ACK: %" PRI_SV " -> %s %s",
+                  PRI_SV_ARGS(tx_str),
+                  str_repr(payload).c_str(),
+                  hex_repr(payload).c_str());
+      }
+      break;
+    case DaikinSerial::Result::Nak:
+      ESP_LOGW(TAG, "NAK for %" PRI_SV, PRI_SV_ARGS(tx_str));
+      break;
+    case DaikinSerial::Result::Timeout:
+      ESP_LOGW(TAG, "Timeout waiting for response to %" PRI_SV, PRI_SV_ARGS(tx_str));
+      break;
+    case DaikinSerial::Result::Error:
+      ESP_LOGE(TAG, "Error with %" PRI_SV, PRI_SV_ARGS(tx_str));
+      break;
+    default:
+      break;
+  }
+
+  // handle serial result
+  switch (result) {
+    case DaikinSerial::Result::Ack:
+      this->comms_detected = true;
+      if (is_query) {
+        // mark as acked
+        this->current_query->acked = true;
+        this->current_query->naks = 0;
+        // save a copy of the payload
+        std::copy_n(payload.begin(), std::min(payload.size(), this->current_query->value.size()), this->current_query->value.begin());
+        if (this->current_query->is_static) {
+          this->static_queries.emplace_back(*this->current_query);
+        }
+        // decode payload
+        if (this->current_query->handler != nullptr) {
+          std::invoke(this->current_query->handler, this, payload);
+        } else {
+          ESP_LOGI(TAG, "Unhandled command: %s", hex_repr(response).c_str());
+        }
+        // print changed values
+        if (is_debug) {
+          ESP_LOGI(TAG, "%" PRI_SV " changed: %s %s -> %s %s",
+                    PRI_SV_ARGS(this->current_query->command),
+                    str_repr(this->current_query->value).c_str(),
+                    hex_repr(this->current_query->value).c_str(),
+                    str_repr(payload).c_str(),
+                    hex_repr(payload).c_str());
+        }
+
+      } else {
+        // nothing yet to do when a command is accepted
       }
       break;
 
     case DaikinSerial::Result::Nak:
-      if (this->tx_command == *(this->current_query)) {
-        ESP_LOGW(TAG, "NAK for %" PRI_SV ", removing from query pool as unsupported", PRI_SV_ARGS(this->tx_command));
-        this->nak_queries.emplace_back(*(this->current_query));
-        // current_query iterator will be invalidated, recover index and recreate
-        const auto index = std::distance(this->queries.begin(), this->current_query);
-        this->queries.erase(this->current_query);
-        this->current_query = this->queries.begin() + index;
+      this->comms_detected = true;
+      if (is_query) {
+        this->current_query->naks++;
       } else {
-        ESP_LOGW(TAG, "NAK for %" PRI_SV " command", PRI_SV_ARGS(this->tx_command));
+        // nothing yet to do when a command is rejected
       }
       break;
 
     case DaikinSerial::Result::Timeout:
-      ESP_LOGW(TAG, "Timeout waiting for response to %" PRI_SV, PRI_SV_ARGS(tx_command));
+      if (is_query) {
+        // It's possible some unsupported queries don't respond at all
+        // Treat these as NAKs if we've established communication
+        // Otherwise, a disconnected or unpowered HVAC unit will quickly cause all queries to fail
+        if (this->comms_detected) {
+          this->current_query->naks++;
+        }
+      } else {
+        // command will be retried, let's hope the code that generates it is bug free
+      }
       break;
 
     case DaikinSerial::Result::Error:
-      this->activate_climate = false;
-      this->activate_swing_mode = false;
-      this->activate_preset = false;
-      this->start_cycle();
-      break;
-
     default:
       break;
+  }
+
+  // update local state for next action
+  if (result == DaikinSerial::Result::Error) {
+    // something went terribly wrong, try to reinitialize communications
+    this->activate_climate = false;
+    this->activate_swing_mode = false;
+    this->activate_preset = false;
+    this->current_command = {};
+    this->start_cycle();
+  } else {
+    if (is_query) {
+      if ((result == DaikinSerial::Result::Ack) && this->current_query->is_static) {
+        // got the query result and know it won't change, remove
+        this->prune_query(this->current_query->command);
+      } else if (this->current_query->naks >= 3) {
+        // query failed, remove
+        ESP_LOGW(TAG, "removing %" PRI_SV " from query pool as unsupported", PRI_SV_ARGS(tx_str));
+        this->failed_queries.emplace_back(this->current_query->command);
+        this->prune_query(this->current_query->command);
+      } else {
+        // next query
+        this->current_query++;
+      }
+      // if all queries have failed we probably had comms then they were lost
+      if (this->queries.empty()) {
+        this->setup();  // reinitialize in order to prepare for the HVAC unit being reconnected
+      }
+    } else {
+      this->current_command = {};
+    }
   }
 }
 
 void DaikinS21::dump_state() {
-  ESP_LOGD(TAG, "** BEGIN STATE *****************************");
-
-  ESP_LOGD(TAG, "  Protocol: %" PRI_SV, PRI_SV_ARGS(protocol_to_string(this->protocol_version)));
+  ESP_LOGD(TAG, "  Connected: %s  Protocol: %" PRI_SV,
+          this->comms_detected ? "true" : "false",
+          PRI_SV_ARGS(protocol_to_string(this->protocol_version)));
   if (this->debug) {
-    ESP_LOGD(TAG, "      G8: %s  GC: %s  GY00: %" PRIu16 "  M: %s  V: %s",
-      str_repr(this->detect_responses.G8).c_str(),
-      str_repr(this->detect_responses.GC).c_str(),
-      this->detect_responses.GY00,
-      str_repr(this->detect_responses.M).c_str(),
-      str_repr(this->detect_responses.V).c_str());
+    const auto old_proto = this->get_static_query(StateQuery::OldProtocol);
+    const auto new_proto = this->get_static_query(StateQuery::NewProtocol);
+    const auto model_code = this->get_static_query(StateQuery::ModelCode);
+    const auto misc_model = this->get_static_query(MiscQuery::Model);
+    const auto misc_version = this->get_static_query(MiscQuery::Version);
+    ESP_LOGD(TAG, "      G8: %s  GC: %s  GY00: %s  M: %s  V: %s",
+      old_proto ? str_repr(*old_proto).c_str() : "N/A",
+      new_proto ? str_repr(*new_proto).c_str() : "N/A",
+      model_code ? str_repr(*model_code).c_str() : "N/A",
+      misc_model ? str_repr(*misc_model).c_str() : "N/A",
+      misc_version ? str_repr(*misc_version).c_str() : "N/A");
   }
   ESP_LOGD(TAG, "   Mode: %s  Action: %s  Preset: %s",
           LOG_STR_ARG(climate::climate_mode_to_string(this->active.mode)),
@@ -732,7 +819,7 @@ void DaikinS21::dump_state() {
   if (this->debug) {
     const auto comma_join = [](const auto& queries) {
       std::string str;
-      for (const auto q : queries) {
+      for (const auto &q : queries) {
         str += q;
         if (q != queries.back()) {
           str += ",";
@@ -740,11 +827,10 @@ void DaikinS21::dump_state() {
       }
       return str;
     };
-    ESP_LOGD(TAG, LOG_STR_ARG(("Queries: " + comma_join(this->queries)).c_str()));
-    ESP_LOGD(TAG, LOG_STR_ARG(("  Nak'd: " + comma_join(this->nak_queries)).c_str()));
+    ESP_LOGD(TAG, LOG_STR_ARG((" Active: " + comma_join(std::views::transform(this->queries, DaikinQueryState::GetCommand))).c_str()));
+    ESP_LOGD(TAG, LOG_STR_ARG(("  Nak'd: " + comma_join(this->failed_queries)).c_str()));
+    ESP_LOGD(TAG, LOG_STR_ARG((" Static: " + comma_join(std::views::transform(this->static_queries, DaikinQueryState::GetCommand))).c_str()));
   }
-
-  ESP_LOGD(TAG, "** END STATE *****************************");
 }
 
 climate::ClimateAction DaikinS21::resolve_climate_action() {

--- a/components/daikin_s21/utils.h
+++ b/components/daikin_s21/utils.h
@@ -13,4 +13,7 @@ namespace esphome::daikin_s21 {
 std::string hex_repr(std::span<const uint8_t> bytes);
 std::string str_repr(std::span<const uint8_t> bytes);
 
+static constexpr uint8_t ahex_digit(uint8_t digit) { return (digit >= 'A') ? (digit - 'A') + 10 : digit - '0'; }
+static constexpr uint8_t ahex_u8_le(uint8_t first, uint8_t second) { return (ahex_digit(second) << 4) | ahex_digit(first); }
+
 } // namespace esphome::daikin_s21


### PR DESCRIPTION
- Add query structures, use instead of std::string_view in query pool.
- Remove monolithic decoding of response, there are no unsolicited responses.
- Track query state and map to handler function.
- Add concept of queries with a static value.
- Store last result in query structures, use this instead of DaikinS21 state.
- Reduce number of ready enum values.
- Add a failsafe attempt if the Daikin unit becomes disconnected from the controller.
- Support a Daikin unit where only one of fine-grained inside or outside temperatures are available.
- Protocol version detection is more robust, add fallback when this fails.
- Use loop() to dump state to avoid warnings about blocking for too long.
- Retry NAK'd queries 3 times, I'll probably revise this or make it less noisy.

Closes #56