### PR TITLE
Add climate humidity sensor, allow finer setpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ESPHome component to control Daikin indoor mini-split units with s21 ports.
 
-Many thanks to the work by [revk][1] on the fantastic [Faikin][2] project, which
-was the primary inspiration and guide for building this ESPHome component. In
-addition, the very active and resourceful community that project has fostered
-that has decoded much of the protocol.
+Many thanks to the work by [revk][1] on the fantastic [Faikin][2] project,
+which was the primary inspiration and guide for building this ESPHome
+component. In addition, the very active and resourceful community that
+project has fostered that has decoded much of the protocol.
 
-A huge thanks to [joshbenner][4], the original author of this integration. His
-[repository][5] would be my preferred place to commit patches to avoid
+A huge thanks to [joshbenner][4], the original author of this integration.
+His [repository][5] would be my preferred place to commit patches to avoid
 fragmentation, but he lacks the time at the moment to manage the project.
 
 ## Features
@@ -16,11 +16,30 @@ fragmentation, but he lacks the time at the moment to manage the project.
 ### Climate
 * Setpoint temperature.
 * Selectable climate modes OFF, HEAT_COOL, COOL, HEAT, FAN_ONLY and DRY.
-* Independent climate action reporting. See what your unit is trying to do, e.g. heating while in HEAT_COOL.
+* Climate action reporting. See what your unit is trying to do, e.g.
+  heating while in HEAT_COOL.
 * Fan modes auto, silent and 1-5.
 * Swing modes horizontal, vertical, and both.
 * Untested support for Powerful and Econo presets ("Boost" and "Eco").
 * Optional humidity reporting.
+* Limits for commanded setpoints. Defaults should work fine, but if your
+  unit is different they can be overridden.
+
+The standard Daikin control loop has a few deficiencies:
+* The setpoint value has 1.0°C granularity.
+* The current temperature feedback value has 0.5°C granularity.
+* The current temperature sensor is located in the unit, in most cases
+  a wall unit placed higher in a room. This reading doesn't always reflect
+  the temperature felt by occupants.
+
+Because of these, the climate component implements a separate loop on top
+of the Daikin internal one. An external temperature sensor can be used
+to provide a more accurate and precise reference and an offset applied to
+the internal Daikin setpoint. The internal temperature sensor can also be
+used for this functionality to drive the coarse setpoint around the more
+granular temperature sensor. The rate at which this secondary loop runs
+is configurable. All of this is downstream of Daikin's reported temperature
+precision and control loop hysteresis, so it's not ideal.
 
 ### Sensor
 * Inside temperature (usually measured at indoor air handler return)
@@ -29,7 +48,8 @@ fragmentation, but he lacks the time at the moment to manage the project.
 * Fan speed
 * Vertical swing angle (directional flap)
 * Compressor frequency (outside exchanger)
-* Humidity (not supported on all units, will report a consistent 50% if not present)
+* Humidity (not supported on all units, will report a consistent 50% if
+  not present)
 * Unit demand from outside exchanger
 
 ### Binary Sensor
@@ -41,7 +61,8 @@ to see how valuable these are. I may remove the redundant ones in the future.
 * Defrost
 * Active (Actively controlling climate, climate action can tell us this)
 * Online (In a climate controlling mode, climate mode can tell us this)
-* Refrigerant Value (shadows active?)
+* Refrigerant Valve (shadows active?)
+* Short Cycle Lock (3 minute compressor lockout)
 * System Defrost (shadows defrost?)
 * Multizone settings conflict
 
@@ -49,16 +70,18 @@ to see how valuable these are. I may remove the redundant ones in the future.
 
 **NOTE:** Currently there's a serious issue when using the Arduino framework.
 If flashed OTA you may lose communication and require a physical reflashing
-(annoying if your board in inside your air handler). Please stick to the ESP-IDF
-PlatformIO framework for now (Arduino is an extra shim over the ESP-IDF SDK anyways).
-See the framework selection in the configuration example.
+(annoying if your board in inside your air handler). Please stick to the
+ESP-IDF PlatformIO framework for now (Arduino is an extra shim over the ESP-IDF
+SDK anyways). See the framework selection in the configuration example.
 
 * This code has only been tested on ESP32 pico and ESP32-S3.
-* Tested with 4MXL36TVJU outdoor unit and CTXS07LVJU, FTXS12LVJU, FTXS15LVJU indoor units.
+* Tested with 4MXL36TVJU outdoor unit and CTXS07LVJU, FTXS12LVJU, FTXS15LVJU
+  indoor units.
 * Powerful and econo modes are untested (no v2 hardware).
 * Does not support comfort or presence detection features on some models.
 * Does not interact with the indoor units schedules (do that with HA instead).
-* Currently targets Version 0 protocol support due to the equipment available to the author.
+* Currently targets Version 0 protocol support due to the equipment available
+  to the author.
 
 ## Hardware
 
@@ -83,20 +106,21 @@ plug pins are at standard 2.5mm pin header widths.
 joshbenner uses the board designed by [revk][1] available [here][3]. Note that
 revk's design includes a FET that inverts the logic levels on the ESP's RX pin,
 which required using two separate UART devices to get around an ESPHome limit
-on having pins inverted differently using the Arduino framework. This handling is
-now moved behind the split_uart component.
+on having pins inverted differently using the Arduino framework. This handling
+is now moved behind the split_uart component.
 
 ### PCB Option 2
 
-I am instead using ESP32-S3 mini dev boards and directly wiring communication to
-the S21 port. The Daikin unit pulls our TX line up to 5V, so the pin should be
-configured as open drain. Instead of driving the line to 0V, it shorts it to
-ground through their external pullup resistor. Your Daikin unit may not have this
-pullup and may need to be added externally to your circuit. Alternatively there
-are cheap level shifter modules available where conventionally driven outputs
-will work. The RX line relies on the ESP32's 5V tolerant GPIO pins. Communication
-works reliably for me. For power I am using a cheap 5V -> 3.3V switching module
-wired into Vcc on the dev board. Don't forget to wire up ground as well.
+I am instead using ESP32-S3 mini dev boards and directly wiring communication
+to the S21 port. The Daikin unit pulls our TX line up to 5V, so the pin should
+be configured as open drain. Instead of driving the line to 0V, it shorts it to
+ground through their external pullup resistor. Your Daikin unit may not have
+this pullup and may need to be added externally to your circuit. Alternatively
+there are cheap level shifter modules available where conventionally driven
+outputs will work. The RX line relies on the ESP32's 5V tolerant GPIO pins.
+Communication works reliably for me. For power I am using a cheap 5V -> 3.3V
+switching module wired into Vcc on the dev board. Don't forget to wire up
+ground as well.
 
 [1]: https://github.com/revk
 [2]: https://github.com/revk/ESP32-Faikin
@@ -106,18 +130,21 @@ wired into Vcc on the dev board. Don't forget to wire up ground as well.
 
 ## Contributing
 
-If you can write C++, great. Even if you're more of a YAML writer and user, your
-assistance with this project would be helpful. Here are some possible ways:
+If you can write C++, great. Even if you're more of a YAML writer and user,
+your assistance with this project would be helpful. Here are some possible
+ways:
 
-* Report your experince with different Daikin units. Turning on protocol debugging
-and getting the protocol detection output values would be the first step if you
-encounter issues and help me learn more about the output of different models.
-* Let me know how useful the binary sensor values are and which just shadow other
-sensor values.
-* If you have a revk module with an inverting RX pin, let me know if using a single
-UART configuration and inverting the RX line with ESPHome's pin schema works with
-ESP-IDF and (when it's working again) the Arduino framework. i.e. Not using the
-split_uart component. If so, I can remove this custom code and simplify configuration.
+* Report your experince with different Daikin units. Turning on protocol
+  debugging and getting the protocol detection output values would be the first
+  step if you encounter issues and help me learn more about the output of
+  different models.
+* Let me know how useful the binary sensor values are and which just shadow
+  other sensor values.
+* If you have a revk module with an inverting RX pin, let me know if using a
+  single UART configuration and inverting the RX line with ESPHome's pin schema
+  works with ESP-IDF and (when it's working again) the Arduino framework. i.e.
+  Not using the split_uart component. If so, I can remove this custom code and
+  simplify configuration.
 
 See existing issues, open a new one or post in the discussions section with
 your findings. Thanks.
@@ -136,8 +163,8 @@ better solution I'll update the example.
 
 When using an external temperature sensor as a room reference instead of the
 internal Daikin value (which may be misleading due to placement of the unit)
-it's recommended to change the target_temperature step to 0.5C to reflect the
-granularity of the alternate control loop provided. The default is 1.0C to
+it's recommended to change the target_temperature step to 0.5°C to reflect the
+granularity of the alternate control loop provided. The default is 1.0°C to
 match Daikin's internal granularity.
 
 ```yaml
@@ -173,9 +200,11 @@ climate:
   - name: My Daikin
     platform: daikin_s21
     # Settings from ESPHome Climate component:
+    # Visual limits and steps can be adjusted to match the granularity of your external sensor:
     # visual:
-    #   target_temperature: 1
-    #   current_temperature: 0.5
+    #   temperature_step:
+    #     target_temperature: 1
+    #     current_temperature: 0.5
     # Settings from DaikinS21Climate:
     supported_modes:  # off and heat_cool are always supported
       - cool
@@ -185,29 +214,37 @@ climate:
     supported_presets:  # none is always supported
       - eco
       - boost
-    supports_humidity: true # If your unit supports humidity, it can be reported in the climate component
-    # Optional HA sensor used to alter setpoint.
-    room_temperature_sensor: room_temp  # See homeassistant sensor below
-    setpoint_interval: 300s # Interval used to adjust the unit's setpoint if the room temperature sensor is specified
+    # Optional sensors to use for temperature and humidity references
+    # sensor: room_temp  # External, see homeassistant sensor below
+    humidity_sensor: daikin_humidity  # Internal, see humidity sensor below
+    # humidity_sensor: room_humidity  # External, see homeassistant sensor below
+    # or leave unconfigured if unsupported to omit reporting
+    update_interval: 60s # Interval used to adjust the unit's setpoint using finer grained control
+    # Daikin supported temperature range setpoints. Defaults should be fine unless your unit differs (see your manual):
+    # max_temperature: 32 # maximum setpoint when cool
+    # max_heat_temperature: 30  # maximum setpoint when heat or heat_cool
+    # min_cool_temperature: 18  # minimum setpoint when cool or heat_cool
+    # min_temperature: 10 # minimum setpoint when heat
 
 # Optional additional sensors.
 sensor:
   - platform: daikin_s21
     inside_temperature:
-      name: My Daikin Inside Temperature
+      name: Inside Temperature
     outside_temperature:
-      name: My Daikin Outside Temperature
+      name: Outside Temperature
       device_id: daikin_outdoor
     coil_temperature:
-      name: My Daikin Coil Temperature
+      name: Coil Temperature
     fan_speed:
-      name: My Daikin Fan Speed
+      name: Fan Speed
     swing_vertical_angle:
       name: Swing Vertical Angle
     compressor_frequency:
       name: Compressor Frequency
       device_id: daikin_outdoor
     humidity:
+      id: daikin_humidity
       name: Humidity
     demand:
       name: Demand  # 0-15 demand units, use filter to map to %
@@ -218,10 +255,17 @@ sensor:
       name: IR Counter
     power_consumption:
       name: Power Consumption
+  # optional external reference sensors
   - platform: homeassistant
     id: room_temp
     entity_id: sensor.office_temperature
     unit_of_measurement: °F
+    accuracy_decimals: 1
+  - platform: homeassistant
+    id: room_humidity
+    entity_id: sensor.office_humidity
+    unit_of_measurement: "%"
+    accuracy_decimals: 1
 
 binary_sensor:
   - platform: daikin_s21

--- a/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.cpp
+++ b/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.cpp
@@ -1,4 +1,5 @@
 #include "daikin_s21_binary_sensor.h"
+#include "../s21.h"
 
 namespace esphome::daikin_s21 {
 
@@ -20,7 +21,7 @@ void DaikinS21BinarySensor::loop() {
     this->defrost_sensor_->publish_state(unit.defrost());
   }
   if (this->active_sensor_ != nullptr) {
-    this->active_sensor_->publish_state(unit.active());  // unit
+    this->active_sensor_->publish_state(this->get_parent()->is_active());  // unit
   }
   if (this->online_sensor_ != nullptr) {
     this->online_sensor_->publish_state(unit.online());

--- a/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.h
+++ b/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.h
@@ -3,7 +3,7 @@
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
-#include "../s21.h"
+#include "../daikin_s21_types.h"
 
 namespace esphome::daikin_s21 {
 

--- a/components/daikin_s21/climate/__init__.py
+++ b/components/daikin_s21/climate/__init__.py
@@ -7,6 +7,10 @@ import esphome.config_validation as cv
 from esphome.components import climate, sensor
 from esphome.components.climate import ClimateMode, ClimatePreset
 from esphome.const import (
+    CONF_HUMIDITY_SENSOR,
+    CONF_MAX_TEMPERATURE,
+    CONF_MIN_TEMPERATURE,
+    CONF_SENSOR,
     CONF_SUPPORTED_MODES,
     CONF_SUPPORTED_PRESETS,
 )
@@ -17,7 +21,7 @@ from .. import (
 )
 
 DaikinS21Climate = daikin_s21_ns.class_(
-    "DaikinS21Climate", climate.Climate, cg.Component
+    "DaikinS21Climate", climate.Climate, cg.PollingComponent
 )
 
 SUPPORTED_CLIMATE_MODES_OPTIONS = {
@@ -34,22 +38,25 @@ SUPPORTED_CLIMATE_PRESETS_OPTIONS = {
     "BOOST": ClimatePreset.CLIMATE_PRESET_BOOST,
 }
 
-CONF_ROOM_TEMPERATURE_SENSOR = "room_temperature_sensor"
-CONF_SUPPORTS_HUMIDITY = "supports_humidity"
-CONF_SETPOINT_INTERVAL = "setpoint_interval"
+CONF_MAX_HEAT_TEMPERATURE = "max_heat_temperature"
+CONF_MIN_COOL_TEMPERATURE = "min_cool_temperature"
 
 CONFIG_SCHEMA = cv.All(
     climate.climate_schema(DaikinS21Climate)
     .extend(
         {
-            cv.Optional(CONF_ROOM_TEMPERATURE_SENSOR): cv.use_id(sensor.Sensor),
-            cv.Optional(CONF_SETPOINT_INTERVAL, default="300s"): cv.positive_time_period_seconds,
+            cv.Optional(CONF_SENSOR): cv.use_id(sensor.Sensor),
+            cv.Optional(CONF_HUMIDITY_SENSOR): cv.use_id(sensor.Sensor),
             cv.Optional(CONF_SUPPORTED_MODES): cv.ensure_list(cv.enum(SUPPORTED_CLIMATE_MODES_OPTIONS, upper=True)),
             cv.Optional(CONF_SUPPORTED_PRESETS): cv.ensure_list(cv.enum(SUPPORTED_CLIMATE_PRESETS_OPTIONS, upper=True)),
-            cv.Optional(CONF_SUPPORTS_HUMIDITY): cv.boolean,
+            cv.Optional(CONF_MAX_TEMPERATURE, default="32"): cv.temperature,
+            cv.Optional(CONF_MAX_HEAT_TEMPERATURE, default="30"): cv.temperature,
+            cv.Optional(CONF_MIN_COOL_TEMPERATURE, default="18"): cv.temperature,
+            cv.Optional(CONF_MIN_TEMPERATURE, default="10"): cv.temperature,
         }
     )
     .extend(S21_PARENT_SCHEMA)
+    .extend(cv.polling_component_schema("0s"))
 )
 
 async def to_code(config):
@@ -57,11 +64,13 @@ async def to_code(config):
     await cg.register_component(var, config)
     await cg.register_parented(var, config[CONF_S21_ID])
 
-    if CONF_ROOM_TEMPERATURE_SENSOR in config:
-        sens = await cg.get_variable(config[CONF_ROOM_TEMPERATURE_SENSOR])
-        cg.add(var.set_room_sensor(sens))
-        if CONF_SETPOINT_INTERVAL in config:
-            cg.add(var.set_setpoint_interval(config[CONF_SETPOINT_INTERVAL]))
+    if CONF_SENSOR in config:
+        sens = await cg.get_variable(config[CONF_SENSOR])
+        cg.add(var.set_temperature_reference_sensor(sens))
+
+    if CONF_HUMIDITY_SENSOR in config:
+        sens = await cg.get_variable(config[CONF_HUMIDITY_SENSOR])
+        cg.add(var.set_humidity_reference_sensor(sens))
 
     if CONF_SUPPORTED_MODES in config:
         cg.add(var.set_supported_modes_override(config[CONF_SUPPORTED_MODES]))
@@ -69,5 +78,14 @@ async def to_code(config):
     if CONF_SUPPORTED_PRESETS in config:
         cg.add(var.set_supported_presets_override(config[CONF_SUPPORTED_PRESETS]))
 
-    if CONF_SUPPORTS_HUMIDITY in config:
-        cg.add(var.set_supports_current_humidity(config[CONF_SUPPORTS_HUMIDITY]))
+    if CONF_MAX_TEMPERATURE in config:
+        cg.add(var.set_max_temperature(config[CONF_MAX_TEMPERATURE]))
+
+    if CONF_MAX_HEAT_TEMPERATURE in config:
+        cg.add(var.set_max_heat_temperature(config[CONF_MAX_HEAT_TEMPERATURE]))
+
+    if CONF_MIN_COOL_TEMPERATURE in config:
+        cg.add(var.set_min_cool_temperature(config[CONF_MIN_COOL_TEMPERATURE]))
+
+    if CONF_MIN_TEMPERATURE in config:
+        cg.add(var.set_min_temperature(config[CONF_MIN_TEMPERATURE]))

--- a/components/daikin_s21/climate/__init__.py
+++ b/components/daikin_s21/climate/__init__.py
@@ -56,7 +56,7 @@ CONFIG_SCHEMA = cv.All(
         }
     )
     .extend(S21_PARENT_SCHEMA)
-    .extend(cv.polling_component_schema("0s"))
+    .extend(cv.polling_component_schema("60s"))
 )
 
 async def to_code(config):

--- a/components/daikin_s21/climate/daikin_s21_climate.h
+++ b/components/daikin_s21/climate/daikin_s21_climate.h
@@ -6,25 +6,29 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/preferences.h"
 #include "../daikin_s21_fan_modes.h"
-#include "../s21.h"
+#include "../daikin_s21_types.h"
 
 namespace esphome::daikin_s21 {
 
 class DaikinS21Climate : public climate::Climate,
-                         public Component,
+                         public PollingComponent,
                          public Parented<DaikinS21> {
  public:
   void setup() override;
   void loop() override;
+  void update() override;
   void dump_config() override;
   void control(const climate::ClimateCall &call) override;
   void update_handler();
 
   void set_supported_modes_override(std::set<climate::ClimateMode> modes);
   void set_supported_presets_override(std::set<climate::ClimatePreset> presets);
-  void set_supports_current_humidity(bool supports_current_humidity);
-  void set_room_sensor(sensor::Sensor *sensor) { this->room_sensor_ = sensor; }
-  void set_setpoint_interval(uint16_t seconds) { this->setpoint_interval_s = seconds; };
+  void set_temperature_reference_sensor(sensor::Sensor *sensor) { this->temperature_sensor_ = sensor; }
+  void set_humidity_reference_sensor(sensor::Sensor *sensor);
+  void set_max_temperature(DaikinC10 temperature) { this->max_temperature = temperature; };
+  void set_max_heat_temperature(DaikinC10 temperature) { this->max_heat_temperature = temperature; };
+  void set_min_cool_temperature(DaikinC10 temperature) { this->min_cool_temperature = temperature; };
+  void set_min_temperature(DaikinC10 temperature) { this->min_temperature = temperature; };
 
  protected:
   static constexpr const char * command_timeout_name = "cmd";
@@ -33,11 +37,15 @@ class DaikinS21Climate : public climate::Climate,
   climate::ClimateTraits traits_{};
   climate::ClimateTraits traits() override { return traits_; };
 
-  sensor::Sensor *room_sensor_{};
-  uint16_t setpoint_interval_s{};
-  uint32_t last_setpoint_check_ms{millis()};
+  sensor::Sensor *temperature_sensor_{};
+  sensor::Sensor *humidity_sensor_{};
+  DaikinC10 max_temperature{};
+  DaikinC10 max_heat_temperature{};
+  DaikinC10 min_cool_temperature{};
+  DaikinC10 min_temperature{};
 
   bool command_active{};  // ESPHome could use a is_timeout_active()...
+  bool check_setpoint{};
   DaikinClimateSettings commanded{};
 
   ESPPreferenceObject auto_setpoint_pref;
@@ -45,18 +53,14 @@ class DaikinS21Climate : public climate::Climate,
   ESPPreferenceObject heat_setpoint_pref;
 
   void set_custom_fan_mode(DaikinFanMode mode);
-  bool use_room_sensor();
-  bool room_sensor_unit_is_valid();
-  float room_sensor_degc();
-  float get_effective_current_temperature();
-  float get_room_temp_offset();
-  float calc_s21_setpoint();
-  float s21_setpoint_variance();
-  void save_setpoint(float value, ESPPreferenceObject &pref);
-  void save_setpoint(float value);
-  optional<float> load_setpoint(ESPPreferenceObject &pref);
-  optional<float> load_setpoint();
-  bool should_check_setpoint();
+  bool temperature_sensor_unit_is_valid();
+  bool use_temperature_sensor();
+  DaikinC10 temperature_sensor_degc();
+  DaikinC10 get_current_temperature();
+  DaikinC10 calc_s21_setpoint();
+  void save_setpoint(DaikinC10 value);
+  DaikinC10 load_setpoint();
+  float get_current_humidity() const;
   void set_s21_climate();
   void command_timeout_handler();
 };

--- a/components/daikin_s21/daikin_s21_queries.h
+++ b/components/daikin_s21/daikin_s21_queries.h
@@ -6,6 +6,7 @@
 #include <string_view>
 #include <span>
 #include "daikin_s21_serial.h"
+#include "daikin_s21_types.h"
 
 namespace esphome::daikin_s21 {
 
@@ -115,8 +116,6 @@ namespace StateCommand {
   inline constexpr std::string_view DJ{"DJ"};
   inline constexpr std::string_view LouvreAngleSetpoint{"DR"};
 }
-
-class DaikinS21;
 
 using PayloadBuffer = std::array<uint8_t, DaikinSerial::STANDARD_PAYLOAD_SIZE>;
 using ExtendedPayloadBuffer = std::array<uint8_t, DaikinSerial::EXTENDED_PAYLOAD_SIZE>;

--- a/components/daikin_s21/daikin_s21_serial.h
+++ b/components/daikin_s21/daikin_s21_serial.h
@@ -6,10 +6,9 @@
 #include "esphome/components/uart/uart.h"
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
+#include "daikin_s21_types.h"
 
 namespace esphome::daikin_s21 {
-
-class DaikinS21;
 
 class DaikinSerial : public Component,
                      public Parented<DaikinS21> {

--- a/components/daikin_s21/daikin_s21_types.h
+++ b/components/daikin_s21/daikin_s21_types.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <compare>
+#include <functional>
+#include <limits>
+#include <type_traits>
+#include "esphome/components/climate/climate.h"
+#include "daikin_s21_fan_modes.h"
+
+namespace esphome::daikin_s21 {
+
+// forward declaration
+class DaikinS21;
+
+class ProtocolVersion {
+ public:
+  uint8_t major{};
+  uint8_t minor{};
+
+  auto operator<=>(const ProtocolVersion&) const = default;
+};
+
+inline constexpr ProtocolVersion ProtocolUndetected{0xFF, 0xFF};
+inline constexpr ProtocolVersion ProtocolUnknown{0,0xFF};  // treat as a protocol 0
+
+/**
+ * Class representing a temperature in degrees C scaled by 10, the most granular internal temperature measurement format
+ */
+class DaikinC10 {
+ public:
+  static constexpr auto nan_sentinel = 500; // internal Daikin 0x80
+
+  constexpr DaikinC10() = default;
+
+  template <typename T, typename std::enable_if_t<std::is_floating_point_v<T>, bool> = true>
+  constexpr DaikinC10(const T valf) : value((static_cast<int16_t>(valf * 10 * 2) + 1) / 2) {} // round to nearest 0.1C
+
+  template <typename T, typename std::enable_if_t<std::is_integral_v<T>, bool> = true>
+  constexpr DaikinC10(const T vali) : value(vali) {}
+
+  explicit constexpr operator float() const { return (value == nan_sentinel) ? NAN : (value / 10.0F); }
+  explicit constexpr operator int16_t() const { return value; }
+  constexpr float f_degc() const { return static_cast<float>(*this); }
+
+  constexpr auto operator<=>(const DaikinC10 &other) const = default;
+  constexpr DaikinC10 operator+(const DaikinC10 &arg) const { return this->value + arg.value; }
+  constexpr DaikinC10 operator-(const DaikinC10 &arg) const { return this->value - arg.value; }
+  constexpr DaikinC10 operator*(const DaikinC10 &arg) const { return this->value * arg.value; }
+  constexpr DaikinC10 operator/(const DaikinC10 &arg) const { return this->value / arg.value; }
+
+  static DaikinC10 diff(const DaikinC10 &a, const DaikinC10 &b) { return std::abs(a.value - b.value); }
+
+ private:
+  int16_t value{};
+};
+
+inline constexpr DaikinC10 SETPOINT_STEP{1.0F}; // Daikin setpoint granularity
+inline constexpr DaikinC10 TEMPERATURE_STEP{0.5F}; // Daikin temperature sensor granularity
+inline constexpr DaikinC10 TEMPERATURE_INVALID{DaikinC10::nan_sentinel}; // NaN
+
+/**
+ * Unit state (RzB2) bitfield decoder
+ */
+class DaikinUnitState {
+ public:
+  constexpr DaikinUnitState(const uint8_t value = 0U) : raw(value) {}
+  constexpr bool powerful() const { return (this->raw & 0x1) != 0; }
+  constexpr bool defrost() const { return (this->raw & 0x2) != 0; }
+  constexpr bool active() const { return (this->raw & 0x4) != 0; }
+  constexpr bool online() const { return (this->raw & 0x8) != 0; }
+  uint8_t raw{};
+};
+
+/**
+ * System state (RzC3) bitfield decoder
+ */
+class DaikinSystemState {
+ public:
+  constexpr DaikinSystemState(const uint8_t value = 0U) : raw(value) {}
+  constexpr bool locked() const { return (this->raw & 0x01) != 0; }
+  constexpr bool active() const { return (this->raw & 0x04) != 0; }
+  constexpr bool defrost() const { return (this->raw & 0x08) != 0; }
+  constexpr bool multizone_conflict() const { return (this->raw & 0x20) != 0; }
+  uint8_t raw{};
+};
+
+struct DaikinClimateSettings {
+  climate::ClimateMode mode{climate::CLIMATE_MODE_OFF};
+  DaikinC10 setpoint{23};
+  climate::ClimateSwingMode swing{climate::CLIMATE_SWING_OFF};
+  DaikinFanMode fan{DaikinFanMode::Auto};
+  climate::ClimatePreset preset{climate::CLIMATE_PRESET_NONE};
+
+  constexpr bool operator==(const DaikinClimateSettings &other) const = default;
+};
+
+} // namespace esphome::daikin_s21

--- a/components/daikin_s21/sensor/__init__.py
+++ b/components/daikin_s21/sensor/__init__.py
@@ -35,6 +35,7 @@ DaikinS21Sensor = daikin_s21_ns.class_(
 )
 
 CONF_INSIDE_TEMP = "inside_temperature"
+CONF_TARGET_TEMP = "target_temperature"
 CONF_OUTSIDE_TEMP = "outside_temperature"
 CONF_COIL_TEMP = "coil_temperature"
 CONF_FAN_SPEED = "fan_speed"
@@ -49,6 +50,12 @@ CONFIG_SCHEMA = (
         {
             cv.GenerateID(): cv.declare_id(DaikinS21Sensor),
             cv.Optional(CONF_INSIDE_TEMP): sensor.sensor_schema(
+                unit_of_measurement=UNIT_CELSIUS,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_TARGET_TEMP): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_TEMPERATURE,
@@ -123,6 +130,7 @@ async def to_code(config):
 
     sensors = (
         (CONF_INSIDE_TEMP, var.set_temp_inside_sensor),
+        (CONF_TARGET_TEMP, var.set_temp_target_sensor),
         (CONF_OUTSIDE_TEMP, var.set_temp_outside_sensor),
         (CONF_COIL_TEMP, var.set_temp_coil_sensor),
         (CONF_FAN_SPEED, var.set_fan_speed_sensor),

--- a/components/daikin_s21/sensor/daikin_s21_sensor.cpp
+++ b/components/daikin_s21/sensor/daikin_s21_sensor.cpp
@@ -1,47 +1,52 @@
 #include "daikin_s21_sensor.h"
+#include "../s21.h"
 
 namespace esphome::daikin_s21 {
 
 static const char *const TAG = "daikin_s21.sensor";
 
 void DaikinS21Sensor::update() {
-  if (!this->get_parent()->is_ready())
-    return;
-  if (this->temp_inside_sensor_ != nullptr) {
-    this->temp_inside_sensor_->publish_state(this->get_parent()->get_temp_inside());
-  }
-  if (this->temp_outside_sensor_ != nullptr) {
-    this->temp_outside_sensor_->publish_state(this->get_parent()->get_temp_outside());
-  }
-  if (this->temp_coil_sensor_ != nullptr) {
-    this->temp_coil_sensor_->publish_state(this->get_parent()->get_temp_coil());
-  }
-  if (this->fan_speed_sensor_ != nullptr) {
-    this->fan_speed_sensor_->publish_state(this->get_parent()->get_fan_rpm());
-  }
-  if (this->swing_vertical_angle_sensor_ != nullptr) {
-    this->swing_vertical_angle_sensor_->publish_state(this->get_parent()->get_swing_vertical_angle());
-  }
-  if (this->compressor_frequency_sensor_ != nullptr) {
-    this->compressor_frequency_sensor_->publish_state(this->get_parent()->get_compressor_frequency());
-  }
-  if (this->humidity_sensor_ != nullptr) {
-    this->humidity_sensor_->publish_state(this->get_parent()->get_humidity());
-  }
-  if (this->demand_sensor_ != nullptr) {
-    this->demand_sensor_->publish_state(this->get_parent()->get_demand());
-  }
-  if (this->ir_counter_sensor_ != nullptr) {
-    this->ir_counter_sensor_->publish_state(this->get_parent()->get_ir_counter());
-  }
-  if (this->power_consumption_sensor_ != nullptr) {
-    this->power_consumption_sensor_->publish_state(this->get_parent()->get_power_consumption() / 100.0F);
+  if (this->get_parent()->is_ready()) {
+    if (this->temp_inside_sensor_ != nullptr) {
+      this->temp_inside_sensor_->publish_state(this->get_parent()->get_temp_inside().f_degc());
+    }
+    if (this->temp_target_sensor_ != nullptr) {
+      this->temp_target_sensor_->publish_state(this->get_parent()->get_temp_target().f_degc());
+    }
+    if (this->temp_outside_sensor_ != nullptr) {
+      this->temp_outside_sensor_->publish_state(this->get_parent()->get_temp_outside().f_degc());
+    }
+    if (this->temp_coil_sensor_ != nullptr) {
+      this->temp_coil_sensor_->publish_state(this->get_parent()->get_temp_coil().f_degc());
+    }
+    if (this->fan_speed_sensor_ != nullptr) {
+      this->fan_speed_sensor_->publish_state(this->get_parent()->get_fan_rpm());
+    }
+    if (this->swing_vertical_angle_sensor_ != nullptr) {
+      this->swing_vertical_angle_sensor_->publish_state(this->get_parent()->get_swing_vertical_angle());
+    }
+    if (this->compressor_frequency_sensor_ != nullptr) {
+      this->compressor_frequency_sensor_->publish_state(this->get_parent()->get_compressor_frequency());
+    }
+    if (this->humidity_sensor_ != nullptr) {
+      this->humidity_sensor_->publish_state(this->get_parent()->get_humidity());
+    }
+    if (this->demand_sensor_ != nullptr) {
+      this->demand_sensor_->publish_state(this->get_parent()->get_demand());
+    }
+    if (this->ir_counter_sensor_ != nullptr) {
+      this->ir_counter_sensor_->publish_state(this->get_parent()->get_ir_counter());
+    }
+    if (this->power_consumption_sensor_ != nullptr) {
+      this->power_consumption_sensor_->publish_state(this->get_parent()->get_power_consumption() / 100.0F);
+    }
   }
 }
 
 void DaikinS21Sensor::dump_config() {
   ESP_LOGCONFIG(TAG, "Daikin S21 Sensor:");
   LOG_SENSOR("  ", "Temperature Inside", this->temp_inside_sensor_);
+  LOG_SENSOR("  ", "Temperature Target", this->temp_target_sensor_);
   LOG_SENSOR("  ", "Temperature Outside", this->temp_outside_sensor_);
   LOG_SENSOR("  ", "Temperature Coil", this->temp_coil_sensor_);
   LOG_SENSOR("  ", "Fan Speed", this->fan_speed_sensor_);

--- a/components/daikin_s21/sensor/daikin_s21_sensor.h
+++ b/components/daikin_s21/sensor/daikin_s21_sensor.h
@@ -3,7 +3,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
-#include "../s21.h"
+#include "../daikin_s21_types.h"
 
 namespace esphome::daikin_s21 {
 
@@ -15,6 +15,9 @@ class DaikinS21Sensor : public PollingComponent,
 
   void set_temp_inside_sensor(sensor::Sensor *sensor) {
     this->temp_inside_sensor_ = sensor;
+  }
+  void set_temp_target_sensor(sensor::Sensor *sensor) {
+    this->temp_target_sensor_ = sensor;
   }
   void set_temp_outside_sensor(sensor::Sensor *sensor) {
     this->temp_outside_sensor_ = sensor;
@@ -46,6 +49,7 @@ class DaikinS21Sensor : public PollingComponent,
 
  protected:
   sensor::Sensor *temp_inside_sensor_{};
+  sensor::Sensor *temp_target_sensor_{};
   sensor::Sensor *temp_outside_sensor_{};
   sensor::Sensor *temp_coil_sensor_{};
   sensor::Sensor *fan_speed_sensor_{};


### PR DESCRIPTION
Configuration:
- Change to PollingComponent, use update_interval instead of setpoint_interval
- Rename room_temperature_sensor to sensor and remove supports_humidity and add humidity_sensor to match ESPHome Climate Thermostat configuration options
- Allow configuration of Daikin climate setpoint limits

Operation:
- Fetch humidity from the sensor and publish as climate humidity
- Fixed point temperature math in climate, use 0.1C granularity
- Try to steer commanded setpoint around desired setpoint when finer than 1.0C steps are used
- Round and bounds check commanded setpoint and publish corrections without involving S21
- Save user setpoint in preferences, not commanded value
- Command and report NAN setpoint for modes where it's not used

Others:
- Move types into their own header
- Use get_unit_of_measurement_ref() instead of std::string
- Remove DaikinC10 fahrenheit conversion and collapse debug strings
- Add target temperature sensor for climate external setpoint debugging
- Read out inferior fan mode when dedicated command missing
- Make active handling clearer in S21 logic
- Update readme

Closes #34 