### PR TITLE
Allow sensor component to free run on core S21 update frequency

### DIFF
--- a/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.cpp
+++ b/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.cpp
@@ -6,7 +6,7 @@ namespace esphome::daikin_s21 {
 static const char *const TAG = "daikin_s21.binary_sensor";
 
 void DaikinS21BinarySensor::setup() {
-  this->get_parent()->binary_sensor_callback = std::bind(&DaikinS21BinarySensor::update_handler, this); // enable update events from DaikinS21
+  this->get_parent()->update_callbacks.add(std::bind(&DaikinS21BinarySensor::update_handler, this)); // enable update events from DaikinS21
   this->disable_loop(); // wait for updates
 }
 

--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -70,7 +70,7 @@ void DaikinS21Climate::setup() {
   // initialize setpoint, will be loaded from preferences or unit shortly
   this->target_temperature = NAN;
   // enable event driven updates
-  this->get_parent()->climate_callback = std::bind(&DaikinS21Climate::update_handler, this); // enable update events from DaikinS21
+  this->get_parent()->update_callbacks.add(std::bind(&DaikinS21Climate::update_handler, this)); // enable update events from DaikinS21
   // allow loop() to execute once to capture the current state (change detection on update requires a "previous" state)
 }
 

--- a/components/daikin_s21/s21.cpp
+++ b/components/daikin_s21/s21.cpp
@@ -135,7 +135,7 @@ void DaikinS21::setup() {
   this->static_queries = {};
   this->protocol_version = ProtocolUndetected;
   this->ready.reset();
-  this->start_poller();
+  this->start_poller(); // for reinit
   this->disable_loop();
 }
 
@@ -591,13 +591,8 @@ void DaikinS21::handle_serial_idle() {
     } else {
       this->current.climate.preset = climate::CLIMATE_PRESET_NONE;
     }
-    // signal there's fresh data
-    if (this->binary_sensor_callback) {
-      this->binary_sensor_callback();
-    }
-    if (this->climate_callback) {
-      this->climate_callback();
-    }
+    // signal there's fresh data to consumers
+    this->update_callbacks.call();
   }
 
   if ((now - last_state_dump_ms) > (60 * 1000)) { // every minute

--- a/components/daikin_s21/s21.h
+++ b/components/daikin_s21/s21.h
@@ -28,8 +28,8 @@ class DaikinS21 : public PollingComponent {
   // external command action
   void set_climate_settings(const DaikinClimateSettings &settings);
 
-  std::function<void(void)> binary_sensor_callback{};
-  std::function<void(void)> climate_callback{};
+  // callbacks called when a query cycle is complete
+  CallbackManager<void(void)> update_callbacks{};
 
   // value accessors
   bool is_ready() { return this->ready.all(); }

--- a/components/daikin_s21/sensor/daikin_s21_sensor.cpp
+++ b/components/daikin_s21/sensor/daikin_s21_sensor.cpp
@@ -5,41 +5,81 @@ namespace esphome::daikin_s21 {
 
 static const char *const TAG = "daikin_s21.sensor";
 
+void DaikinS21Sensor::setup() {
+  if (this->is_free_run()) {
+    this->get_parent()->update_callbacks.add(std::bind(&DaikinS21Sensor::update_handler, this));
+  }
+  this->disable_loop(); // wait for updates
+}
+
+/**
+ * ESPHome Component loop
+ *
+ * Deferred work from update_handler()
+ *
+ * Publish the sensors and wait for further updates.
+ */
+void DaikinS21Sensor::loop() {
+  this->publish_sensors();
+  this->disable_loop();
+}
+
+/**
+ * ESPHome PollingComponent loop
+ *
+ * Publishes sensors on user interval when S21 is ready.
+ */
 void DaikinS21Sensor::update() {
   if (this->get_parent()->is_ready()) {
-    if (this->temp_inside_sensor_ != nullptr) {
-      this->temp_inside_sensor_->publish_state(this->get_parent()->get_temp_inside().f_degc());
-    }
-    if (this->temp_target_sensor_ != nullptr) {
-      this->temp_target_sensor_->publish_state(this->get_parent()->get_temp_target().f_degc());
-    }
-    if (this->temp_outside_sensor_ != nullptr) {
-      this->temp_outside_sensor_->publish_state(this->get_parent()->get_temp_outside().f_degc());
-    }
-    if (this->temp_coil_sensor_ != nullptr) {
-      this->temp_coil_sensor_->publish_state(this->get_parent()->get_temp_coil().f_degc());
-    }
-    if (this->fan_speed_sensor_ != nullptr) {
-      this->fan_speed_sensor_->publish_state(this->get_parent()->get_fan_rpm());
-    }
-    if (this->swing_vertical_angle_sensor_ != nullptr) {
-      this->swing_vertical_angle_sensor_->publish_state(this->get_parent()->get_swing_vertical_angle());
-    }
-    if (this->compressor_frequency_sensor_ != nullptr) {
-      this->compressor_frequency_sensor_->publish_state(this->get_parent()->get_compressor_frequency());
-    }
-    if (this->humidity_sensor_ != nullptr) {
-      this->humidity_sensor_->publish_state(this->get_parent()->get_humidity());
-    }
-    if (this->demand_sensor_ != nullptr) {
-      this->demand_sensor_->publish_state(this->get_parent()->get_demand());
-    }
-    if (this->ir_counter_sensor_ != nullptr) {
-      this->ir_counter_sensor_->publish_state(this->get_parent()->get_ir_counter());
-    }
-    if (this->power_consumption_sensor_ != nullptr) {
-      this->power_consumption_sensor_->publish_state(this->get_parent()->get_power_consumption() / 100.0F);
-    }
+    this->publish_sensors();
+  }
+}
+
+/**
+ * Update handler
+ *
+ * Called by DaikinS21 on every complete system state update.
+ */
+void DaikinS21Sensor::update_handler() {
+  this->enable_loop_soon_any_context();  // defer publish to next loop()
+}
+
+/**
+ * Unconditionally publish the sensors
+ */
+void DaikinS21Sensor::publish_sensors() {
+  if (this->temp_inside_sensor_ != nullptr) {
+    this->temp_inside_sensor_->publish_state(this->get_parent()->get_temp_inside().f_degc());
+  }
+  if (this->temp_target_sensor_ != nullptr) {
+    this->temp_target_sensor_->publish_state(this->get_parent()->get_temp_target().f_degc());
+  }
+  if (this->temp_outside_sensor_ != nullptr) {
+    this->temp_outside_sensor_->publish_state(this->get_parent()->get_temp_outside().f_degc());
+  }
+  if (this->temp_coil_sensor_ != nullptr) {
+    this->temp_coil_sensor_->publish_state(this->get_parent()->get_temp_coil().f_degc());
+  }
+  if (this->fan_speed_sensor_ != nullptr) {
+    this->fan_speed_sensor_->publish_state(this->get_parent()->get_fan_rpm());
+  }
+  if (this->swing_vertical_angle_sensor_ != nullptr) {
+    this->swing_vertical_angle_sensor_->publish_state(this->get_parent()->get_swing_vertical_angle());
+  }
+  if (this->compressor_frequency_sensor_ != nullptr) {
+    this->compressor_frequency_sensor_->publish_state(this->get_parent()->get_compressor_frequency());
+  }
+  if (this->humidity_sensor_ != nullptr) {
+    this->humidity_sensor_->publish_state(this->get_parent()->get_humidity());
+  }
+  if (this->demand_sensor_ != nullptr) {
+    this->demand_sensor_->publish_state(this->get_parent()->get_demand());
+  }
+  if (this->ir_counter_sensor_ != nullptr) {
+    this->ir_counter_sensor_->publish_state(this->get_parent()->get_ir_counter());
+  }
+  if (this->power_consumption_sensor_ != nullptr) {
+    this->power_consumption_sensor_->publish_state(this->get_parent()->get_power_consumption() / 100.0F);
   }
 }
 

--- a/components/daikin_s21/sensor/daikin_s21_sensor.h
+++ b/components/daikin_s21/sensor/daikin_s21_sensor.h
@@ -10,8 +10,13 @@ namespace esphome::daikin_s21 {
 class DaikinS21Sensor : public PollingComponent,
                         public Parented<DaikinS21> {
  public:
+  void setup() override;
+  void loop() override;
   void update() override;
   void dump_config() override;
+
+  void update_handler();
+  void publish_sensors();
 
   void set_temp_inside_sensor(sensor::Sensor *sensor) {
     this->temp_inside_sensor_ = sensor;
@@ -48,6 +53,8 @@ class DaikinS21Sensor : public PollingComponent,
   }
 
  protected:
+  bool is_free_run() const { return this->get_update_interval() == 0; }
+
   sensor::Sensor *temp_inside_sensor_{};
   sensor::Sensor *temp_target_sensor_{};
   sensor::Sensor *temp_outside_sensor_{};


### PR DESCRIPTION
Set sensor polling interval to zero seconds to enable this. It's recommended to limit these updates somehow if you do this: either run the core S21 polling logic at a slower rate or (better) configure delta filters on your sensors so only changes get pushed to HA.

* Switch to a single callback manager now that there are a few update callbacks with the same signature.
* Update readme.
* Disable the sensor loop when in polling mode.

Closes #75 

3s resolution vertical swing angle:
<img width="1088" height="428" alt="Screenshot 2025-09-23 at 8 34 33 PM" src="https://github.com/user-attachments/assets/d4a2ecd6-8fe8-4426-98a9-a1b1eda4bc4e" />