### PR TITLE
Don't overwrite user climate modes when specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A big thanks to:
 * Setpoint temperature.
 * Selectable climate modes OFF, HEAT_COOL, COOL, HEAT, FAN_ONLY and DRY.
 * Climate action reporting. See what your unit is trying to do, e.g.
-  heating while in HEAT_COOL.
+  heating or cooling while in HEAT_COOL.
 * Fan modes auto, silent and 1-5.
 * Swing modes horizontal, vertical, and both.
 * Untested support for Powerful and Econo presets ("Boost" and "Eco").
@@ -264,7 +264,8 @@ climate:
     #     target_temperature: 1
     #     current_temperature: 0.5
     # Settings from DaikinS21Climate:
-    supported_modes:  # off and heat_cool are always supported
+    supported_modes:  # off is always supported
+      - heat_cool
       - cool
       - heat
       - dry
@@ -278,11 +279,12 @@ climate:
     # humidity_sensor: room_humidity  # External, see homeassistant sensor below
     # or leave unconfigured if unsupported to omit reporting
     # update_interval: 60s # Interval used to adjust the unit's setpoint using finer grained control
-    # Daikin supported temperature range setpoints. Defaults should be fine unless your unit differs (see your manual):
-    # max_temperature: 32 # maximum setpoint when cool
-    # max_heat_temperature: 30  # maximum setpoint when heat or heat_cool
+    # Daikin internal supported temperature range setpoints, used to prevent sending out of range values to the unit.
+    # Defaults should be fine unless your unit differs (see your manual):
+    # max_cool_temperature: 32 # maximum setpoint when cool
     # min_cool_temperature: 18  # minimum setpoint when cool or heat_cool
-    # min_temperature: 10 # minimum setpoint when heat
+    # max_heat_temperature: 30  # maximum setpoint when heat or heat_cool
+    # min_heat_temperature: 10 # minimum setpoint when heat
 
 # Optional additional sensors.
 sensor:

--- a/components/daikin_s21/climate/__init__.py
+++ b/components/daikin_s21/climate/__init__.py
@@ -8,8 +8,6 @@ from esphome.components import climate, sensor
 from esphome.components.climate import ClimateMode, ClimatePreset
 from esphome.const import (
     CONF_HUMIDITY_SENSOR,
-    CONF_MAX_TEMPERATURE,
-    CONF_MIN_TEMPERATURE,
     CONF_SENSOR,
     CONF_SUPPORTED_MODES,
     CONF_SUPPORTED_PRESETS,
@@ -26,7 +24,7 @@ DaikinS21Climate = daikin_s21_ns.class_(
 
 SUPPORTED_CLIMATE_MODES_OPTIONS = {
     "OFF": ClimateMode.CLIMATE_MODE_OFF,  # always available
-    "HEAT_COOL": ClimateMode.CLIMATE_MODE_HEAT_COOL,  # always available
+    "HEAT_COOL": ClimateMode.CLIMATE_MODE_HEAT_COOL,
     "COOL": ClimateMode.CLIMATE_MODE_COOL,
     "HEAT": ClimateMode.CLIMATE_MODE_HEAT,
     "FAN_ONLY": ClimateMode.CLIMATE_MODE_FAN_ONLY,
@@ -38,8 +36,11 @@ SUPPORTED_CLIMATE_PRESETS_OPTIONS = {
     "BOOST": ClimatePreset.CLIMATE_PRESET_BOOST,
 }
 
-CONF_MAX_HEAT_TEMPERATURE = "max_heat_temperature"
+CONF_MAX_COOL_TEMPERATURE = "max_cool_temperature"
 CONF_MIN_COOL_TEMPERATURE = "min_cool_temperature"
+CONF_MAX_HEAT_TEMPERATURE = "max_heat_temperature"
+CONF_MIN_HEAT_TEMPERATURE = "min_heat_temperature"
+
 
 CONFIG_SCHEMA = cv.All(
     climate.climate_schema(DaikinS21Climate)
@@ -49,10 +50,10 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_HUMIDITY_SENSOR): cv.use_id(sensor.Sensor),
             cv.Optional(CONF_SUPPORTED_MODES): cv.ensure_list(cv.enum(SUPPORTED_CLIMATE_MODES_OPTIONS, upper=True)),
             cv.Optional(CONF_SUPPORTED_PRESETS): cv.ensure_list(cv.enum(SUPPORTED_CLIMATE_PRESETS_OPTIONS, upper=True)),
-            cv.Optional(CONF_MAX_TEMPERATURE, default="32"): cv.temperature,
-            cv.Optional(CONF_MAX_HEAT_TEMPERATURE, default="30"): cv.temperature,
+            cv.Optional(CONF_MAX_COOL_TEMPERATURE, default="32"): cv.temperature,
             cv.Optional(CONF_MIN_COOL_TEMPERATURE, default="18"): cv.temperature,
-            cv.Optional(CONF_MIN_TEMPERATURE, default="10"): cv.temperature,
+            cv.Optional(CONF_MAX_HEAT_TEMPERATURE, default="30"): cv.temperature,
+            cv.Optional(CONF_MIN_HEAT_TEMPERATURE, default="10"): cv.temperature,
         }
     )
     .extend(S21_PARENT_SCHEMA)
@@ -78,14 +79,14 @@ async def to_code(config):
     if CONF_SUPPORTED_PRESETS in config:
         cg.add(var.set_supported_presets_override(config[CONF_SUPPORTED_PRESETS]))
 
-    if CONF_MAX_TEMPERATURE in config:
-        cg.add(var.set_max_temperature(config[CONF_MAX_TEMPERATURE]))
-
-    if CONF_MAX_HEAT_TEMPERATURE in config:
-        cg.add(var.set_max_heat_temperature(config[CONF_MAX_HEAT_TEMPERATURE]))
+    if CONF_MAX_COOL_TEMPERATURE in config:
+        cg.add(var.set_max_cool_temperature(config[CONF_MAX_COOL_TEMPERATURE]))
 
     if CONF_MIN_COOL_TEMPERATURE in config:
         cg.add(var.set_min_cool_temperature(config[CONF_MIN_COOL_TEMPERATURE]))
 
-    if CONF_MIN_TEMPERATURE in config:
-        cg.add(var.set_min_temperature(config[CONF_MIN_TEMPERATURE]))
+    if CONF_MAX_HEAT_TEMPERATURE in config:
+        cg.add(var.set_max_heat_temperature(config[CONF_MAX_HEAT_TEMPERATURE]))
+
+    if CONF_MIN_HEAT_TEMPERATURE in config:
+        cg.add(var.set_min_heat_temperature(config[CONF_MIN_HEAT_TEMPERATURE]))

--- a/components/daikin_s21/climate/daikin_s21_climate.h
+++ b/components/daikin_s21/climate/daikin_s21_climate.h
@@ -25,10 +25,10 @@ class DaikinS21Climate : public climate::Climate,
   void set_supported_presets_override(std::set<climate::ClimatePreset> presets);
   void set_temperature_reference_sensor(sensor::Sensor *sensor) { this->temperature_sensor_ = sensor; }
   void set_humidity_reference_sensor(sensor::Sensor *sensor);
-  void set_max_temperature(DaikinC10 temperature) { this->max_temperature = temperature; };
-  void set_max_heat_temperature(DaikinC10 temperature) { this->max_heat_temperature = temperature; };
+  void set_max_cool_temperature(DaikinC10 temperature) { this->max_cool_temperature = temperature; };
   void set_min_cool_temperature(DaikinC10 temperature) { this->min_cool_temperature = temperature; };
-  void set_min_temperature(DaikinC10 temperature) { this->min_temperature = temperature; };
+  void set_max_heat_temperature(DaikinC10 temperature) { this->max_heat_temperature = temperature; };
+  void set_min_heat_temperature(DaikinC10 temperature) { this->min_heat_temperature = temperature; };
 
  protected:
   static constexpr const char * command_timeout_name = "cmd";
@@ -39,10 +39,10 @@ class DaikinS21Climate : public climate::Climate,
 
   sensor::Sensor *temperature_sensor_{};
   sensor::Sensor *humidity_sensor_{};
-  DaikinC10 max_temperature{};
-  DaikinC10 max_heat_temperature{};
+  DaikinC10 max_cool_temperature{};
   DaikinC10 min_cool_temperature{};
-  DaikinC10 min_temperature{};
+  DaikinC10 max_heat_temperature{};
+  DaikinC10 min_heat_temperature{};
 
   bool command_active{};  // ESPHome could use a is_timeout_active()...
   bool check_setpoint{};

--- a/components/daikin_s21/daikin_s21_types.h
+++ b/components/daikin_s21/daikin_s21_types.h
@@ -108,7 +108,7 @@ struct DaikinClimateSettings {
 using DaikinModel = uint16_t;
 inline constexpr DaikinModel ModelUnknown{0xFFFF};
 
-// V0 outdoor units?
+// V0 model families?
 inline constexpr DaikinModel ModelRXB35C2V1B{0x2806}; // indoor FTXB25C2V1B
 inline constexpr DaikinModel Model4MXL36TVJU{0x35E3}; // indoor CTXS07LVJU, FTXS12LVJU, FTXS15LVJU
 inline constexpr DaikinModel ModelRXC24AXVJU{0x4431}; // indoor FTXC24AXVJU


### PR DESCRIPTION
- Don't overwrite user climate modes when specified
- Support cooling-only systems, don't hardcode support for heat_cool
- Rename climate max_temperature and min_temperature optional config name keys to indicate mode they're used

Closese #76 