### PR TITLE
Fix log macros to compile for ESP8266 / Arduino

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ On my Daikin units, the S21 port has the following pins:
 
 1. Vref (5V) Reference for communications, not to be used for powering your
   device. Sometimes N/C.
-2. TX (5V)
-3. RX (5V)
+2. TX (5V) Daikin Tx, ESPHome Rx
+3. RX (5V) Daikin Rx, ESPHome Tx
 4. Vcc (>5V!)
 5. GND
 
@@ -151,8 +151,8 @@ Do not connect anything to pin 10. Don't populate it in your plug.
 1. Vcc (>5V!)
 2. JEM-A OUT (pull down = ON)
 3. JEM-A IN (pull down = toggle switch)
-4. TX (5V)
-5. RX (5V)
+4. TX (5V) Daikin Tx, ESPHome Rx
+5. RX (5V) Daikin Rx, ESPHome Tx
 6. GND
 7. GND
 8. N/C

--- a/components/daikin_s21/s21.cpp
+++ b/components/daikin_s21/s21.cpp
@@ -1012,9 +1012,9 @@ void DaikinS21::dump_state() {
       }
       return str;
     };
-    ESP_LOGD(TAG, LOG_STR_ARG((" Active: " + comma_join(std::views::transform(this->queries, DaikinQueryState::GetCommand))).c_str()));
-    ESP_LOGD(TAG, LOG_STR_ARG(("  Nak'd: " + comma_join(this->failed_queries)).c_str()));
-    ESP_LOGD(TAG, LOG_STR_ARG((" Static: " + comma_join(std::views::transform(this->static_queries, DaikinQueryState::GetCommand))).c_str()));
+    ESP_LOGD(TAG, " Active: %s", LOG_STR_ARG(comma_join(std::views::transform(this->queries, DaikinQueryState::GetCommand)).c_str()));
+    ESP_LOGD(TAG, "  Nak'd: %s", LOG_STR_ARG(comma_join(this->failed_queries).c_str()));
+    ESP_LOGD(TAG, " Static: %s", LOG_STR_ARG(comma_join(std::views::transform(this->static_queries, DaikinQueryState::GetCommand)).c_str()));
   }
 }
 


### PR DESCRIPTION
Fix log macros to compile for ESP8266 / Arduino

document rx/tx perspectives in readme