### PR TITLE
Fix the uart setting (pin attribute) was loaded to default while setting

### DIFF
--- a/components/daikin_s21/daikin_s21_serial.cpp
+++ b/components/daikin_s21/daikin_s21_serial.cpp
@@ -20,7 +20,6 @@ void DaikinSerial::setup() {
   this->uart.set_stop_bits(2);
   this->uart.set_data_bits(8);
   this->uart.set_parity(uart::UART_CONFIG_PARITY_EVEN);
-  this->uart.load_settings();
   // start idle, wait for updates
   this->disable_loop();
 }


### PR DESCRIPTION
The pin attribute was changed to default that causes Faikin board not work. #80 