### PR TITLE
Improve readout loop speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ protocol available over S21 and related ports.
 
 A big thanks to:
 * [revk](https://github.com/revk) for work on the fantastic
-  [Faikin](https://github.com/revk/ESP32-Faikin) project, which was the primary
+  [Faikout](https://github.com/revk/ESP32-Faikout) (née Faikin) project, which was the primary
   inspiration and guide for building this ESPHome component. In addition, the
   very active and resourceful community that project has fostered that has
   decoded much of the protocol.
@@ -92,7 +92,7 @@ Not all units support these.
 
 ### Text Sensor
 
-If you've read the Faikin wiki you'll see many more queries available than
+If you've read the Faikout wiki you'll see many more queries available than
 what this project supports. I've added a text_sensor component to read these
 raw values out for debugging and protocol decoding use, without having to add
 a dedicated sensor. Normally you wouldn't need to use this, but if a value
@@ -124,7 +124,7 @@ this writing, independent UART pin inversion control also wasn't possible.
 
 ## Hardware
 
-Please see the Faikin [wiring](https://github.com/revk/ESP32-Faikin/wiki/Wiring)
+Please see the Faikout [wiring](https://github.com/revk/ESP32-Faikout/wiki/Wiring)
 page for detailed documentation including pinouts, alternate connectors with
 images. The below is just a quick reference overview.
 
@@ -177,7 +177,7 @@ Contacts: JST `SXA-001T-P0.6`
 
 ### PCB Option 1
 
-joshbenner uses the board designed by revk available [here](https://github.com/revk/ESP32-Faikin/tree/main/PCB/Faikin).
+joshbenner uses the board designed by revk available [here](https://github.com/revk/ESP32-Faikout/tree/main/PCB/Faikout).
 Note that revk's design includes a FET that inverts the logic levels on the
 ESP's RX pin, and on newer revisions the TX pin as well. When interfacing
 through a FET the RX line should be configured with a pullup. This handling
@@ -206,7 +206,7 @@ ways:
   other sensor values.
 
 Please consider documenting characteristics of your unit in the appropriate
-place in the Faikin wiki. I don't want to make an inferior copy of this
+place in the Faikout wiki. I don't want to make an inferior copy of this
 information if possible. Please don't report issues with this component to them
 as we don't share a codebase. Some of the readout values here are not
 byteswapped if we don't otherwise use them so unknown static fields may appear
@@ -246,6 +246,9 @@ esp32:
 
 logger:
   baud_rate: 0  # Disable UART logger if using UART0 (pins 1,3)
+
+preferences:
+  flash_write_interval: 72h
 
 external_components:
   - source: github://asund/esphome-daikin-s21@main
@@ -387,7 +390,7 @@ binary_sensor:
 ```
 
 Here is an example of how daikin_s21 can be used with inverted UART pins
-and an RX pullup (newer Faikin PCB rev):
+and an RX pullup (newer Faikout PCB rev):
 
 ```yaml
 uart:

--- a/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.h
+++ b/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.h
@@ -4,6 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 #include "../daikin_s21_types.h"
+#include "../s21.h"
 
 namespace esphome::daikin_s21 {
 
@@ -16,27 +17,34 @@ class DaikinS21BinarySensor : public Component,
 
   void set_powerful_sensor(binary_sensor::BinarySensor *sensor) {
     this->powerful_sensor_ = sensor;
+    this->get_parent()->request_readout(DaikinS21::ReadoutUnitStateBits);
   }
   void set_defrost_sensor(binary_sensor::BinarySensor *sensor) {
     this->defrost_sensor_ = sensor;
+    this->get_parent()->request_readout(DaikinS21::ReadoutUnitStateBits);
   }
   void set_active_sensor(binary_sensor::BinarySensor *sensor) {
     this->active_sensor_ = sensor;
   }
   void set_online_sensor(binary_sensor::BinarySensor *sensor) {
     this->online_sensor_ = sensor;
+    this->get_parent()->request_readout(DaikinS21::ReadoutUnitStateBits);
   }
   void set_valve_sensor(binary_sensor::BinarySensor *sensor) {
     this->valve_sensor_ = sensor;
+    this->get_parent()->request_readout(DaikinS21::ReadoutSystemStateBits);
   }
   void set_short_cycle_sensor(binary_sensor::BinarySensor *sensor) {
     this->short_cycle_sensor_ = sensor;
+    this->get_parent()->request_readout(DaikinS21::ReadoutSystemStateBits);
   }
   void set_system_defrost_sensor(binary_sensor::BinarySensor *sensor) {
     this->system_defrost_sensor_ = sensor;
+    this->get_parent()->request_readout(DaikinS21::ReadoutSystemStateBits);
   }
-    void set_multizone_conflict_sensor(binary_sensor::BinarySensor *sensor) {
+  void set_multizone_conflict_sensor(binary_sensor::BinarySensor *sensor) {
     this->multizone_conflict_sensor_ = sensor;
+    this->get_parent()->request_readout(DaikinS21::ReadoutSystemStateBits);
   }
 
  protected:

--- a/components/daikin_s21/climate/__init__.py
+++ b/components/daikin_s21/climate/__init__.py
@@ -18,6 +18,8 @@ from .. import (
     S21_PARENT_SCHEMA,
 )
 
+AUTO_LOAD = ["sensor"]
+
 DaikinS21Climate = daikin_s21_ns.class_(
     "DaikinS21Climate", climate.Climate, cg.PollingComponent
 )
@@ -41,7 +43,6 @@ CONF_MAX_COOL_TEMPERATURE = "max_cool_temperature"
 CONF_MIN_COOL_TEMPERATURE = "min_cool_temperature"
 CONF_MAX_HEAT_TEMPERATURE = "max_heat_temperature"
 CONF_MIN_HEAT_TEMPERATURE = "min_heat_temperature"
-
 
 CONFIG_SCHEMA = (
     climate.climate_schema(DaikinS21Climate)

--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -137,9 +137,7 @@ void DaikinS21Climate::loop() {
         this->check_setpoint = false;
         if (DaikinC10::diff(reported.setpoint, this->calc_s21_setpoint()) >= SETPOINT_STEP) { // in setpoint mode, calculated won't be invalid
           if (this->use_temperature_sensor()) {
-            ESP_LOGD(TAG, "Temperature from external sensor: %.1f %s (%.1f °C)  Offset: %.1f",
-                this->temperature_sensor_->get_state(),
-                this->temperature_sensor_->get_unit_of_measurement_ref().c_str(),
+            ESP_LOGD(TAG, "Temperature from external sensor: %.1f Offset: %.1f",
                 current_temperature,
                 this->get_parent()->get_temp_inside() - this->temperature_sensor_degc());
           }
@@ -235,6 +233,7 @@ void DaikinS21Climate::set_supported_modes(std::set<climate::ClimateMode> modes)
  */
 void DaikinS21Climate::set_supported_presets(std::set<climate::ClimatePreset> presets) {
   this->traits_.set_supported_presets(presets);
+  this->get_parent()->request_readout(DaikinS21::ReadoutPresets);
 }
 
 /**
@@ -322,7 +321,7 @@ DaikinC10 DaikinS21Climate::calc_s21_setpoint() {
 }
 
 void DaikinS21Climate::save_setpoint(const DaikinC10 value) {
-  // Only save if value is different from what's already saved.
+  // Only save if value is different from what's already saved. Some platforms don't support this internally.
   if (value != this->load_setpoint()) {
     const int16_t save_val = static_cast<int16_t>(value);
     switch (this->mode) {

--- a/components/daikin_s21/s21.h
+++ b/components/daikin_s21/s21.h
@@ -28,6 +28,30 @@ class DaikinS21 : public PollingComponent {
   // external command action
   void set_climate_settings(const DaikinClimateSettings &settings);
 
+  enum ReadoutRequest {
+    // binary sensor
+    ReadoutUnitStateBits,
+    ReadoutSystemStateBits,
+    // climate
+    ReadoutPresets,
+    // sensor
+    ReadoutTemperatureTarget,
+    ReadoutTemperatureOutside,
+    ReadoutTemperatureCoil,
+    ReadoutFanSpeed,
+    ReadoutSwingAngle,
+    ReadoutCompressorFrequency,
+    ReadoutHumidity,
+    ReadoutDemand,
+    ReadoutIRCounter,
+    ReadoutPowerConsumption,
+    // just for bitset sizing
+    ReadoutCount,
+  };
+  void request_readout(const ReadoutRequest request) {
+    this->readout_requests.set(request);
+  }
+
   std::vector<std::string_view> debug_queries{};
 
   // callbacks called when a query cycle is complete
@@ -35,7 +59,7 @@ class DaikinS21 : public PollingComponent {
 
   // value accessors
   bool is_ready() { return this->ready.all(); }
-  const DaikinClimateSettings& get_climate_settings() { return this->current.climate; };
+  const DaikinClimateSettings& get_climate_settings() { return this->current.climate; }
   auto get_climate_mode() { return this->current.climate.mode; }
   auto get_climate_action() { return this->current.action; }
   auto get_temp_setpoint() { return this->current.climate.setpoint; }
@@ -72,6 +96,7 @@ class DaikinS21 : public PollingComponent {
     ReadySensorReadout,
     ReadyModelDetection,
     ReadyActiveSource,
+    ReadyPowerfulSource,
     ReadyCount, // just for bitset sizing
   };
   std::bitset<ReadyCount> ready{};
@@ -86,6 +111,7 @@ class DaikinS21 : public PollingComponent {
   bool comms_detected() const { return this->protocol_version != ProtocolUndetected; }
   bool cycle_triggered{};
   bool cycle_active{};
+  std::bitset<ReadoutCount> readout_requests{};
   std::vector<DaikinQueryState> queries{};
   std::size_t query_index{};
   auto current_query() { return this->queries.begin() + this->query_index; }

--- a/components/daikin_s21/sensor/daikin_s21_sensor.h
+++ b/components/daikin_s21/sensor/daikin_s21_sensor.h
@@ -4,6 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 #include "../daikin_s21_types.h"
+#include "../s21.h"
 
 namespace esphome::daikin_s21 {
 
@@ -22,33 +23,43 @@ class DaikinS21Sensor : public PollingComponent,
   }
   void set_temp_target_sensor(sensor::Sensor *sensor) {
     this->temp_target_sensor_ = sensor;
+    this->get_parent()->request_readout(DaikinS21::ReadoutTemperatureTarget);
   }
   void set_temp_outside_sensor(sensor::Sensor *sensor) {
     this->temp_outside_sensor_ = sensor;
+    this->get_parent()->request_readout(DaikinS21::ReadoutTemperatureOutside);
   }
   void set_temp_coil_sensor(sensor::Sensor *sensor) {
     this->temp_coil_sensor_ = sensor;
+    this->get_parent()->request_readout(DaikinS21::ReadoutTemperatureCoil);
   }
   void set_fan_speed_sensor(sensor::Sensor *sensor) {
     this->fan_speed_sensor_ = sensor;
+    this->get_parent()->request_readout(DaikinS21::ReadoutFanSpeed);
   }
   void set_swing_vertical_angle_sensor(sensor::Sensor *sensor) {
     this->swing_vertical_angle_sensor_ = sensor;
+    this->get_parent()->request_readout(DaikinS21::ReadoutSwingAngle);
   }
   void set_compressor_frequency_sensor(sensor::Sensor *sensor) {
     this->compressor_frequency_sensor_ = sensor;
+    this->get_parent()->request_readout(DaikinS21::ReadoutCompressorFrequency);
   }
   void set_humidity_sensor(sensor::Sensor *sensor) {
     this->humidity_sensor_ = sensor;
+    this->get_parent()->request_readout(DaikinS21::ReadoutHumidity);
   }
   void set_demand_sensor(sensor::Sensor *sensor) {
     this->demand_sensor_ = sensor;
+    this->get_parent()->request_readout(DaikinS21::ReadoutDemand);
   }
   void set_ir_counter_sensor(sensor::Sensor *sensor) {
     this->ir_counter_sensor_ = sensor;
+    this->get_parent()->request_readout(DaikinS21::ReadoutIRCounter);
   }
   void set_power_consumption_sensor(sensor::Sensor *sensor) {
     this->power_consumption_sensor_ = sensor;
+    this->get_parent()->request_readout(DaikinS21::ReadoutPowerConsumption);
   }
 
  protected:


### PR DESCRIPTION
Schedule independent queries only when required by external components
Add sensor module AUTO_LOAD to climate component, closes #93
Don't roll our own std::atoi
Don't print reference sensor units in debugging, it's converted to celsius so use that
Rename references to Faikin project