### PR TITLE
Refactor query handling

### DIFF
--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -74,7 +74,7 @@ void DaikinS21Climate::setup() {
  * Publish any state changes to Home Assistant.
  */
 void DaikinS21Climate::loop() {
-  const auto& reported = this->get_parent()->get_climate_settings();
+  const auto &reported = this->get_parent()->get_climate_settings();
 
   // If an active command took effect, cancel the timeout and lift the publication ban
   if (this->command_active && (this->commanded == reported)) {
@@ -431,7 +431,7 @@ void DaikinS21Climate::set_s21_climate() {
   ESP_LOGI(TAG, "  Swing: %s", LOG_STR_ARG(climate::climate_swing_mode_to_string(this->commanded.swing)));
   ESP_LOGI(TAG, "  Preset: %s", LOG_STR_ARG(climate::climate_preset_to_string(this->commanded.preset)));
 
-  this->save_setpoint(this->target_temperature);  // todo much slower interval?
+  this->save_setpoint(this->target_temperature);
 }
 
 } // namespace esphome::daikin_s21

--- a/components/daikin_s21/daikin_s21_serial.cpp
+++ b/components/daikin_s21/daikin_s21_serial.cpp
@@ -71,7 +71,7 @@ void DaikinSerial::loop() {
             break;
 
           case ACK:
-            ESP_LOGD(TAG, "Rx STX: Repeated ACK, ignoring"); // on rare occasions my unit will do this
+            ESP_LOGV(TAG, "Rx STX: Repeated ACK, ignoring"); // on rare occasions my unit will do this, not harmful
             break;
 
           default:

--- a/components/daikin_s21/daikin_s21_serial.h
+++ b/components/daikin_s21/daikin_s21_serial.h
@@ -15,7 +15,7 @@ class DaikinSerial : public Component,
  public:
   static constexpr std::size_t MAX_COMMAND_SIZE{6};
   static constexpr std::size_t STANDARD_PAYLOAD_SIZE{5};
-  static constexpr std::size_t EXTENDED_PAYLOAD_SIZE{14}; // for MiscQuery::SoftwareVersion
+  static constexpr std::size_t EXTENDED_PAYLOAD_SIZE{32};
   static constexpr std::size_t MAX_RESPONSE_SIZE{MAX_COMMAND_SIZE + EXTENDED_PAYLOAD_SIZE + 1U};  // +1 for checksum
 
   enum class Result : uint8_t {

--- a/components/daikin_s21/text_sensor/daikin_s21_text_sensor.cpp
+++ b/components/daikin_s21/text_sensor/daikin_s21_text_sensor.cpp
@@ -8,9 +8,10 @@ namespace esphome::daikin_s21 {
 static const char *const TAG = "daikin_s21.text_sensor";
 
 void DaikinS21TextSensor::setup() {
+  for (const auto &sensor : this->sensors) {
+    this->get_parent()->add_debug_query(sensor->get_name().c_str());  // register queries
+  }
   this->get_parent()->update_callbacks.add([this](){ this->enable_loop_soon_any_context(); }); // enable update events from DaikinS21
-  const auto query_strings = std::views::transform(this->sensors, [](const auto sensor){ return sensor->get_name().c_str(); });
-  this->get_parent()->debug_queries = {query_strings.begin(), query_strings.end()}; // register queries
   this->disable_loop(); // wait for updates
 }
 
@@ -24,8 +25,7 @@ void DaikinS21TextSensor::setup() {
 void DaikinS21TextSensor::loop() {
   // update all sensors
   for (auto * const sensor : this->sensors) {
-    auto result = this->get_parent()->get_query_result(sensor->get_name().c_str());
-    std::string current_state = str_repr(result.value);
+    std::string current_state = str_repr(this->get_parent()->get_query_result(sensor->get_name().c_str()));
     if (sensor->state != current_state) {
       sensor->publish_state(current_state);
     }

--- a/components/daikin_s21/utils.h
+++ b/components/daikin_s21/utils.h
@@ -13,8 +13,4 @@ namespace esphome::daikin_s21 {
 std::string hex_repr(std::span<const uint8_t> bytes);
 std::string str_repr(std::span<const uint8_t> bytes);
 
-static constexpr uint8_t ahex_digit(const uint8_t digit) { return (digit >= 'A') ? (digit - 'A') + 10 : digit - '0'; }
-static constexpr uint8_t ahex_u8_le(const uint8_t first, const uint8_t second) { return ahex_digit(first) + (ahex_digit(second) << 4); }
-static constexpr uint16_t ahex_u16_le(std::span<const uint8_t> bytes) { return ahex_u8_le(bytes[0], bytes[1]) + (ahex_u8_le(bytes[2], bytes[3]) << 8); }
-
 } // namespace esphome::daikin_s21


### PR DESCRIPTION
- Consolidate query state into one class.
- Use a dynamic result buffer when needed, remove special handling for software version.
- Prepopulate a single vector of queries, track more state within them.
- Use references when getting results.
- Slim down handle_serial_result.
- Remove ReadyBasic gating, a few query cycles occur before publishing already.

Extras
- Split up refine_queries into helper functions. State was independent anyways.
- Demote duplicate Ack message to verbose. Doesn't affect things, not interesting to see.
- Increase result buffer size to accommodate future queries.
- Remove hex conversion routines, make use of std::strtoul.
- More use of std::ranges.