### PR TITLE
Fix active source detection when unit state isn't available

### DIFF
--- a/components/daikin_s21/text_sensor/daikin_s21_text_sensor.cpp
+++ b/components/daikin_s21/text_sensor/daikin_s21_text_sensor.cpp
@@ -24,8 +24,10 @@ void DaikinS21TextSensor::setup() {
  */
 void DaikinS21TextSensor::loop() {
   if (this->statics_done == false) {
-    software_version_sensor_->publish_state(this->get_parent()->get_software_version());
-    statics_done = true;
+    if (this->software_version_sensor_ != nullptr) {
+      this->software_version_sensor_->publish_state(this->get_parent()->get_software_version());
+    }
+    this->statics_done = true;
   }
   // update all debug sensors
   for (auto * const sensor : this->sensors) {


### PR DESCRIPTION
- After checking if unit state can be enabled and doing so, I never handled the disabled case. Treat as unavailable and follow action.

- Fix detection of protocol v2 when receiving an unexpected response to new protocol query

- Fix version string decoding on V0 and a crash when the text_sensor component is enabled but software version isn't

Hopefully fixes #102 