### PR TITLE
Logging and otherwise cleanup

### DIFF
--- a/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.cpp
+++ b/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.cpp
@@ -3,7 +3,7 @@
 
 namespace esphome::daikin_s21 {
 
-static const char *const TAG = "daikin_s21.binary_sensor";
+static const char * const TAG = "daikin_s21.binary_sensor";
 
 void DaikinS21BinarySensor::setup() {
   this->get_parent()->update_callbacks.add([this](){ this->enable_loop_soon_any_context(); }); // enable update events from DaikinS21

--- a/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.h
+++ b/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.h
@@ -21,7 +21,7 @@ class DaikinS21BinarySensor : public Component,
   void loop() override;
   void dump_config() override;
 
-  void set_mode_sensor(DaikinS21BinarySensorMode *mode_sensor) {
+  void set_mode_sensor(DaikinS21BinarySensorMode * const mode_sensor) {
     this->mode_sensors_[mode_sensor->mode] = mode_sensor;
     if (mode_sensor->mode == ModePowerful) {
       this->get_parent()->request_readout(DaikinS21::ReadoutPowerful);
@@ -31,34 +31,34 @@ class DaikinS21BinarySensor : public Component,
       this->get_parent()->request_readout(DaikinS21::ReadoutSpecialModes);
     }
   }
-  void set_defrost_sensor(binary_sensor::BinarySensor *sensor) {
+  void set_defrost_sensor(binary_sensor::BinarySensor * const sensor) {
     this->defrost_sensor_ = sensor;
     this->get_parent()->request_readout(DaikinS21::ReadoutUnitStateBits);
   }
-  void set_active_sensor(binary_sensor::BinarySensor *sensor) {
+  void set_active_sensor(binary_sensor::BinarySensor * const sensor) {
     this->active_sensor_ = sensor;
   }
-  void set_online_sensor(binary_sensor::BinarySensor *sensor) {
+  void set_online_sensor(binary_sensor::BinarySensor * const sensor) {
     this->online_sensor_ = sensor;
     this->get_parent()->request_readout(DaikinS21::ReadoutUnitStateBits);
   }
-  void set_valve_sensor(binary_sensor::BinarySensor *sensor) {
+  void set_valve_sensor(binary_sensor::BinarySensor * const sensor) {
     this->valve_sensor_ = sensor;
     this->get_parent()->request_readout(DaikinS21::ReadoutSystemStateBits);
   }
-  void set_short_cycle_sensor(binary_sensor::BinarySensor *sensor) {
+  void set_short_cycle_sensor(binary_sensor::BinarySensor * const sensor) {
     this->short_cycle_sensor_ = sensor;
     this->get_parent()->request_readout(DaikinS21::ReadoutSystemStateBits);
   }
-  void set_system_defrost_sensor(binary_sensor::BinarySensor *sensor) {
+  void set_system_defrost_sensor(binary_sensor::BinarySensor * const sensor) {
     this->system_defrost_sensor_ = sensor;
     this->get_parent()->request_readout(DaikinS21::ReadoutSystemStateBits);
   }
-  void set_multizone_conflict_sensor(binary_sensor::BinarySensor *sensor) {
+  void set_multizone_conflict_sensor(binary_sensor::BinarySensor * const sensor) {
     this->multizone_conflict_sensor_ = sensor;
     this->get_parent()->request_readout(DaikinS21::ReadoutSystemStateBits);
   }
-  void set_serial_error_sensor(binary_sensor::BinarySensor *sensor) {
+  void set_serial_error_sensor(binary_sensor::BinarySensor * const sensor) {
     this->serial_error_sensor_ = sensor;
     this->get_parent()->request_readout(DaikinS21::ReadoutErrorStatus);
   }

--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -9,7 +9,7 @@ using namespace esphome;
 
 namespace esphome::daikin_s21 {
 
-static const char *const TAG = "daikin_s21.climate";
+static const char * const TAG = "daikin_s21.climate";
 
 /**
  * Save setpoint for the mode to persistent storage.

--- a/components/daikin_s21/climate/daikin_s21_climate.h
+++ b/components/daikin_s21/climate/daikin_s21_climate.h
@@ -32,8 +32,8 @@ class DaikinS21Climate : public climate::Climate,
 
   void set_supported_modes(climate::ClimateModeMask modes);
   void set_supported_swing_modes(climate::ClimateSwingModeMask swing_modes);
-  void set_temperature_reference_sensor(sensor::Sensor *sensor) { this->temperature_sensor_ = sensor; }
-  void set_humidity_reference_sensor(sensor::Sensor *sensor);
+  void set_temperature_reference_sensor(sensor::Sensor * const sensor) { this->temperature_sensor_ = sensor; }
+  void set_humidity_reference_sensor(sensor::Sensor * sensor);
   void set_setpoint_mode_config(climate::ClimateMode mode, DaikinC10 offset, DaikinC10 min, DaikinC10 max);
 
  protected:

--- a/components/daikin_s21/daikin_s21_queries.cpp
+++ b/components/daikin_s21/daikin_s21_queries.cpp
@@ -5,7 +5,7 @@
 
 namespace esphome::daikin_s21 {
 
-static const char *const TAG = "daikin_s21.queries";
+static const char * const TAG = "daikin_s21.queries";
 
 /**
  * Copy the last result into the query instance and records the length.

--- a/components/daikin_s21/daikin_s21_serial.cpp
+++ b/components/daikin_s21/daikin_s21_serial.cpp
@@ -7,7 +7,7 @@
 
 namespace esphome::daikin_s21 {
 
-static const char *const TAG = "daikin_s21.serial";
+static const char * const TAG = "daikin_s21.serial";
 
 static constexpr uint8_t STX{2};
 static constexpr uint8_t ETX{3};

--- a/components/daikin_s21/daikin_s21_serial.h
+++ b/components/daikin_s21/daikin_s21_serial.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <span>
 #include <string_view>
+#include <vector>
 #include "esphome/components/uart/uart.h"
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
@@ -25,12 +26,12 @@ class DaikinSerial : public Component,
     Error,
   };
 
-  DaikinSerial(uart::UARTComponent *uart) : uart(*uart) {}
+  DaikinSerial(uart::UARTComponent * const uart) : uart(*uart) {}
 
   void setup() override;
   void loop() override;
   void dump_config() override;
-  void set_debug(bool set) { this->debug = set; }
+  void set_debug(const bool set) { this->debug = set; }
 
   void send_frame(std::string_view cmd, std::span<const uint8_t> payload = {});
 

--- a/components/daikin_s21/number/daikin_s21_number.cpp
+++ b/components/daikin_s21/number/daikin_s21_number.cpp
@@ -3,7 +3,7 @@
 
 namespace esphome::daikin_s21 {
 
-static const char *const TAG = "daikin_s21.number";
+static const char * const TAG = "daikin_s21.number";
 
 void DaikinS21NumberDemand::control(const float value) {
   this->get_parent()->set_demand_control(value);

--- a/components/daikin_s21/number/daikin_s21_number.h
+++ b/components/daikin_s21/number/daikin_s21_number.h
@@ -20,7 +20,7 @@ class DaikinS21Number : public Component,
   void loop() override;
   void dump_config() override;
 
-  void set_demand(DaikinS21NumberDemand *number) {
+  void set_demand(DaikinS21NumberDemand * const number) {
     this->demand_number_ = number;
   }
 

--- a/components/daikin_s21/s21.cpp
+++ b/components/daikin_s21/s21.cpp
@@ -10,7 +10,7 @@ using namespace esphome;
 
 namespace esphome::daikin_s21 {
 
-static const char *const TAG = "daikin_s21";
+static const char * const TAG = "daikin_s21";
 
 constexpr uint8_t climate_mode_to_s21(const climate::ClimateMode mode) {
   switch (mode) {

--- a/components/daikin_s21/s21.h
+++ b/components/daikin_s21/s21.h
@@ -22,7 +22,7 @@ class DaikinS21 : public PollingComponent {
   void loop() override;
   void update() override;
   void dump_config() override;
-  void set_debug(bool set) { this->debug = set; }
+  void set_debug(const bool set) { this->debug = set; }
 
   // external command action
   void set_climate_settings(DaikinClimateSettings climate);

--- a/components/daikin_s21/select/daikin_s21_select.cpp
+++ b/components/daikin_s21/select/daikin_s21_select.cpp
@@ -3,7 +3,7 @@
 
 namespace esphome::daikin_s21 {
 
-static const char *const TAG = "daikin_s21.select";
+static const char * const TAG = "daikin_s21.select";
 
 void DaikinS21SelectHumidity::control(const size_t index) {
   this->get_parent()->set_humidity_mode(static_cast<DaikinHumidityMode>(index));

--- a/components/daikin_s21/select/daikin_s21_select.h
+++ b/components/daikin_s21/select/daikin_s21_select.h
@@ -26,12 +26,12 @@ class DaikinS21Select : public Component,
   void loop() override;
   void dump_config() override;
 
-  void set_humidity_select(DaikinS21SelectHumidity *humidity_select) {
+  void set_humidity_select(DaikinS21SelectHumidity * const humidity_select) {
     this->humidity_select_ = humidity_select;
     this->get_parent()->request_readout(DaikinS21::ReadoutSwingHumidty);
   }
 
-  void set_vertical_swing_select(DaikinS21SelectVerticalSwing *vertical_swing_select) {
+  void set_vertical_swing_select(DaikinS21SelectVerticalSwing * const vertical_swing_select) {
     this->vertical_swing_select_ = vertical_swing_select;
     this->get_parent()->request_readout(DaikinS21::ReadoutVerticalSwingMode);
   }

--- a/components/daikin_s21/sensor/daikin_s21_sensor.cpp
+++ b/components/daikin_s21/sensor/daikin_s21_sensor.cpp
@@ -3,7 +3,7 @@
 
 namespace esphome::daikin_s21 {
 
-static const char *const TAG = "daikin_s21.sensor";
+static const char * const TAG = "daikin_s21.sensor";
 
 void DaikinS21Sensor::setup() {
   if (this->is_free_run()) {

--- a/components/daikin_s21/sensor/daikin_s21_sensor.h
+++ b/components/daikin_s21/sensor/daikin_s21_sensor.h
@@ -18,53 +18,53 @@ class DaikinS21Sensor : public PollingComponent,
 
   void publish_sensors();
 
-  void set_temp_setpoint_sensor(sensor::Sensor *sensor) {
+  void set_temp_setpoint_sensor(sensor::Sensor * const sensor) {
     this->temp_setpoint_sensor_ = sensor;
   }
-  void set_temp_inside_sensor(sensor::Sensor *sensor) {
+  void set_temp_inside_sensor(sensor::Sensor * const sensor) {
     this->temp_inside_sensor_ = sensor;
   }
-  void set_temp_target_sensor(sensor::Sensor *sensor) {
+  void set_temp_target_sensor(sensor::Sensor * const sensor) {
     this->temp_target_sensor_ = sensor;
     this->get_parent()->request_readout(DaikinS21::ReadoutTemperatureTarget);
   }
-  void set_temp_outside_sensor(sensor::Sensor *sensor) {
+  void set_temp_outside_sensor(sensor::Sensor * const sensor) {
     this->temp_outside_sensor_ = sensor;
     this->get_parent()->request_readout(DaikinS21::ReadoutTemperatureOutside);
   }
-  void set_temp_coil_sensor(sensor::Sensor *sensor) {
+  void set_temp_coil_sensor(sensor::Sensor * const sensor) {
     this->temp_coil_sensor_ = sensor;
     this->get_parent()->request_readout(DaikinS21::ReadoutTemperatureCoil);
   }
-  void set_fan_speed_sensor(sensor::Sensor *sensor) {
+  void set_fan_speed_sensor(sensor::Sensor * const sensor) {
     this->fan_speed_sensor_ = sensor;
     this->get_parent()->request_readout(DaikinS21::ReadoutFanSpeed);
   }
-  void set_swing_vertical_angle_sensor(sensor::Sensor *sensor) {
+  void set_swing_vertical_angle_sensor(sensor::Sensor * const sensor) {
     this->swing_vertical_angle_sensor_ = sensor;
     this->get_parent()->request_readout(DaikinS21::ReadoutSwingAngle);
   }
-  void set_compressor_frequency_sensor(sensor::Sensor *sensor) {
+  void set_compressor_frequency_sensor(sensor::Sensor * const sensor) {
     this->compressor_frequency_sensor_ = sensor;
     this->get_parent()->request_readout(DaikinS21::ReadoutCompressorFrequency);
   }
-  void set_humidity_sensor(sensor::Sensor *sensor) {
+  void set_humidity_sensor(sensor::Sensor * const sensor) {
     this->humidity_sensor_ = sensor;
     this->get_parent()->request_readout(DaikinS21::ReadoutHumidity);
   }
-  void set_demand_sensor(sensor::Sensor *sensor) {
+  void set_demand_sensor(sensor::Sensor * const sensor) {
     this->demand_sensor_ = sensor;
     this->get_parent()->request_readout(DaikinS21::ReadoutDemand);
   }
-  void set_ir_counter_sensor(sensor::Sensor *sensor) {
+  void set_ir_counter_sensor(sensor::Sensor * const sensor) {
     this->ir_counter_sensor_ = sensor;
     this->get_parent()->request_readout(DaikinS21::ReadoutIRCounter);
   }
-  void set_power_consumption_sensor(sensor::Sensor *sensor) {
+  void set_power_consumption_sensor(sensor::Sensor * const sensor) {
     this->power_consumption_sensor_ = sensor;
     this->get_parent()->request_readout(DaikinS21::ReadoutPowerConsumption);
   }
-  void set_outdoor_capacity_sensor(sensor::Sensor *sensor) {
+  void set_outdoor_capacity_sensor(sensor::Sensor * const sensor) {
     this->outdoor_capacity_sensor_ = sensor;
     this->get_parent()->request_readout(DaikinS21::ReadoutOutdoorCapacity);
   }

--- a/components/daikin_s21/switch/daikin_s21_switch.cpp
+++ b/components/daikin_s21/switch/daikin_s21_switch.cpp
@@ -2,7 +2,7 @@
 
 namespace esphome::daikin_s21 {
 
-static const char *const TAG = "daikin_s21.switch";
+static const char * const TAG = "daikin_s21.switch";
 
 void DaikinS21Switch::setup() {
   this->get_parent()->update_callbacks.add([this](){ this->enable_loop_soon_any_context(); }); // enable update events from DaikinS21

--- a/components/daikin_s21/switch/daikin_s21_switch.h
+++ b/components/daikin_s21/switch/daikin_s21_switch.h
@@ -24,7 +24,7 @@ class DaikinS21Switch : public Component,
   void loop() override;
   void dump_config() override;
 
-  void set_mode_switch(DaikinS21SwitchMode *mode_switch) {
+  void set_mode_switch(DaikinS21SwitchMode * const mode_switch) {
     this->mode_switches_[mode_switch->mode] = mode_switch;
     if (mode_switch->mode == ModePowerful) {
       this->get_parent()->request_readout(DaikinS21::ReadoutPowerful);

--- a/components/daikin_s21/text_sensor/daikin_s21_text_sensor.cpp
+++ b/components/daikin_s21/text_sensor/daikin_s21_text_sensor.cpp
@@ -5,7 +5,7 @@
 
 namespace esphome::daikin_s21 {
 
-static const char *const TAG = "daikin_s21.text_sensor";
+static const char * const TAG = "daikin_s21.text_sensor";
 
 void DaikinS21TextSensor::setup() {
   for (const auto &sensor : this->sensors) {
@@ -43,10 +43,6 @@ void DaikinS21TextSensor::loop() {
     }
   }
   this->disable_loop(); // wait for further updates
-}
-
-void DaikinS21TextSensor::set_debug_query_sensors(std::vector<text_sensor::TextSensor *> &&sensors) {
-  this->sensors = sensors;
 }
 
 void DaikinS21TextSensor::dump_config() {

--- a/components/daikin_s21/text_sensor/daikin_s21_text_sensor.h
+++ b/components/daikin_s21/text_sensor/daikin_s21_text_sensor.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <vector>
+#include <initializer_list>
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
@@ -17,26 +17,28 @@ class DaikinS21TextSensor : public Component,
   void loop() override;
   void dump_config() override;
 
-  void set_model_sensor(text_sensor::TextSensor *sensor) {
+  void set_model_sensor(text_sensor::TextSensor * const sensor) {
     this->model_sensor_ = sensor;
   }
 
-  void set_software_revision_sensor(text_sensor::TextSensor *sensor) {
+  void set_software_revision_sensor(text_sensor::TextSensor * const sensor) {
     this->software_revision_sensor_ = sensor;
   }
 
-  void set_software_version_sensor(text_sensor::TextSensor *sensor) {
+  void set_software_version_sensor(text_sensor::TextSensor * const sensor) {
     this->software_version_sensor_ = sensor;
   }
 
-  void set_debug_query_sensors(std::vector<text_sensor::TextSensor *> &&sensors);
+  void set_debug_query_sensors(const std::initializer_list<text_sensor::TextSensor *> init_list) {
+    this->sensors = init_list;
+  }
 
  protected:
   bool statics_done{};
   text_sensor::TextSensor *model_sensor_{};
   text_sensor::TextSensor *software_revision_sensor_{};
   text_sensor::TextSensor *software_version_sensor_{};
-  std::vector<text_sensor::TextSensor *> sensors{};
+  FixedVector<text_sensor::TextSensor *> sensors{};
 };
 
 } // namespace esphome::daikin_s21


### PR DESCRIPTION
- Switch to FixedVector for debug text sensors, save some flash
- Make some parameters const
- Use cached app loop start time instead of `millis()` per ESPHome coding guide
- Remove recent null checks where implemented in ESPHome internally already
- Strip leading line from platform dump_config, TAG will convey source when components dump themselves
- Make use of the component type field of log statements
- Remove use of LOG_STR_ARG where parameter isn't LogString
- Add a use of PRI_SV_ARGS in response length validation message
- Add a couple configuration dump messages