### PR TITLE
Add additional energy consumption sensors for protocols 3.20+

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ A big thanks to:
 A short changelog of sorts, I'll keep things here where a user might encounter
 breaking or significant changes.
 
+* Added additional energy consumption sensors for protocol 3.20+. Renamed
+  existing "power_consumption" to "energy_indoor". Sorry. Update your YAML.
 * Checksum calculation was fixed. There's a faint chance that a command that was
   previously NAK'd actually now works.
 * Custom Silent fan mode changed to standard Quiet. Custom Automatic was also
@@ -171,8 +173,13 @@ example configuration.
 v2+ protocol units may also support:
 
 * IR counter that increments when the remote is used.
-* Total power consumption in kWh.
+* Energy consumption of all indoor units in kWh.
 * Outdoor unit capacity in indoor units.
+
+v3.20+ protocol units may also support:
+
+* Energy consumption in cooling and heating modes in kWh, including the outside
+  unit's use, for this inside unit.
 
 ### Binary Sensor
 
@@ -506,13 +513,23 @@ sensor:
       name: IR Counter
       filters:
         - delta: 0.0
-    power_consumption:
-      name: Power Consumption
+    energy_indoor:
+      name: Energy Consumption Indoor
+      device_id: daikin_outdoor # this is the sum of all indoor units on an outdoor unit
       filters:
         - delta: 0.0
     outdoor_capacity:
       name: Outdoor Capacity
       device_id: daikin_outdoor
+      filters:
+        - delta: 0.0
+    # Protocol Version 3.20:
+    energy_cooling:
+      name: Energy Consumption Cooling
+      filters:
+        - delta: 0.0
+    energy_heating:
+      name: Energy Consumption Heating
       filters:
         - delta: 0.0
   # optional external reference sensors

--- a/components/daikin_s21/daikin_s21_queries.h
+++ b/components/daikin_s21/daikin_s21_queries.h
@@ -26,7 +26,7 @@ namespace StateQuery {
   inline constexpr std::string_view IRCounter{"FG"};
   inline constexpr std::string_view V2OptionalFeatures{"FK"};
   // FL
-  inline constexpr std::string_view PowerConsumption{"FM"};
+  inline constexpr std::string_view EnergyConsumptionIndoorUnits{"FM"};
   inline constexpr std::string_view ITELC{"FN"};
   inline constexpr std::string_view FP{"FP"};
   inline constexpr std::string_view FQ{"FQ"};
@@ -35,7 +35,7 @@ namespace StateQuery {
   inline constexpr std::string_view OutdoorCapacity{"FT"};
   inline constexpr std::string_view V3OptionalFeatures{"FU00"};
   inline constexpr std::string_view AllowedTemperatureRange{"FU02"};
-  inline constexpr std::string_view Uptime{"FU04"};
+  inline constexpr std::string_view EnergyConsumptionClimateModes{"FU04"};
   inline constexpr std::string_view ModelName{"FU05"};
   inline constexpr std::string_view ProductionInformation{"FU15"};
   inline constexpr std::string_view ProductionOrder{"FU25"};

--- a/components/daikin_s21/s21.h
+++ b/components/daikin_s21/s21.h
@@ -47,8 +47,9 @@ class DaikinS21 : public PollingComponent {
     ReadoutHumidity,
     ReadoutDemand,
     ReadoutIRCounter,
-    ReadoutPowerConsumption,
+    ReadoutEnergyConsumptionIndoorUnits,
     ReadoutOutdoorCapacity,
+    ReadoutEnergyConsumptionClimateModes,
     // select
     ReadoutVerticalSwingMode,
     // multiple components
@@ -84,7 +85,9 @@ class DaikinS21 : public PollingComponent {
   auto get_swing_vertical_angle_setpoint() const { return this->swing_vertical_angle_setpoint; }
   auto get_swing_vertical_angle() const { return this->swing_vertical_angle; }
   auto get_ir_counter() const { return this->ir_counter; }
-  auto get_power_consumption() const { return this->power_consumption; }
+  auto get_energy_consumption_indoor_units() const { return this->energy_consumption_indoor_units; }
+  auto get_energy_consumption_cooling() const { return this->energy_consumption_cooling; }
+  auto get_energy_consumption_heating() const { return this->energy_consumption_heating; }
   auto get_vertical_swing_mode() const { return this->vertical_swing_mode.value(); }
   auto get_outdoor_capacity() const { return this->outdoor_capacity; }
   auto get_compressor_frequency() const { return this->compressor_rpm; }
@@ -151,10 +154,11 @@ class DaikinS21 : public PollingComponent {
   void handle_state_inside_outside_temperature(std::span<const uint8_t> payload);
   void handle_state_model_code_v2(std::span<const uint8_t> payload);
   void handle_state_ir_counter(std::span<const uint8_t> payload);
-  void handle_state_power_consumption(std::span<const uint8_t> payload);
+  void handle_state_energy_consumption_indoor_units(std::span<const uint8_t> payload);
   void handle_vertical_swing_mode(std::span<const uint8_t> payload);
   void handle_state_outdoor_capacity(std::span<const uint8_t> payload);
   void handle_state_model_name(std::span<const uint8_t> payload);
+  void handle_state_energy_consumption_climate_modes(std::span<const uint8_t> payload);
   void handle_state_software_revision(std::span<const uint8_t> payload);
   void handle_state_model_v3(std::span<const uint8_t> payload);
   void handle_env_power_on_off(std::span<const uint8_t> payload);
@@ -193,6 +197,8 @@ class DaikinS21 : public PollingComponent {
   CommandState<DaikinVerticalSwingMode> vertical_swing_mode{};
 
   // current values
+  uint32_t energy_consumption_cooling{};
+  uint32_t energy_consumption_heating{};
   DaikinC10 temp_inside{};
   DaikinC10 temp_target{};
   DaikinC10 temp_outside{};
@@ -203,7 +209,7 @@ class DaikinS21 : public PollingComponent {
   int16_t swing_vertical_angle_setpoint{};  // not supported
   int16_t swing_vertical_angle{};
   uint16_t ir_counter{};
-  uint16_t power_consumption{};
+  uint16_t energy_consumption_indoor_units{};
   uint8_t humidity{50};
   uint8_t demand_pull{};
   climate::ClimateAction action_reported = climate::CLIMATE_ACTION_OFF; // raw readout

--- a/components/daikin_s21/sensor/__init__.py
+++ b/components/daikin_s21/sensor/__init__.py
@@ -34,13 +34,15 @@ DaikinS21Sensor = daikin_s21_ns.class_("DaikinS21Sensor", cg.PollingComponent)
 
 CONF_COIL_TEMP = "coil_temperature"
 CONF_COMPRESSOR_FREQUENCY = "compressor_frequency"
+CONF_ENERGY_COOLING = "energy_cooling"
+CONF_ENERGY_HEATING = "energy_heating"
+CONF_ENERGY_INDOOR = "energy_indoor"
 CONF_DEMAND = "demand"
 CONF_FAN_SPEED = "fan_speed"
 CONF_IR_COUNTER = "ir_counter"
 CONF_INSIDE_TEMP = "inside_temperature"
 CONF_OUTDOOR_CAPACITY = "outdoor_capacity"
 CONF_OUTSIDE_TEMP = "outside_temperature"
-CONF_POWER_CONSUMPTION = "power_consumption"
 CONF_SETPOINT_TEMP = "setpoint_temperature"
 CONF_SWING_VERTICAL_ANGLE = "swing_vertical_angle"
 
@@ -48,6 +50,12 @@ TEMPERATURE_SENSOR_SCHEMA = sensor.sensor_schema(
     unit_of_measurement=UNIT_CELSIUS,
     accuracy_decimals=1,
     device_class=DEVICE_CLASS_TEMPERATURE,
+    state_class=STATE_CLASS_MEASUREMENT,
+)
+ENERGY_SENSOR_SCHEMA = sensor.sensor_schema(
+    unit_of_measurement=UNIT_KILOWATT_HOURS,
+    accuracy_decimals=2,
+    device_class=DEVICE_CLASS_ENERGY,
     state_class=STATE_CLASS_MEASUREMENT,
 )
 
@@ -70,6 +78,9 @@ CONFIG_SCHEMA = (
             accuracy_decimals=1,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
+        cv.Optional(CONF_ENERGY_COOLING): ENERGY_SENSOR_SCHEMA,
+        cv.Optional(CONF_ENERGY_HEATING): ENERGY_SENSOR_SCHEMA,
+        cv.Optional(CONF_ENERGY_INDOOR): ENERGY_SENSOR_SCHEMA,
         cv.Optional(CONF_FAN_SPEED): sensor.sensor_schema(
             unit_of_measurement=UNIT_REVOLUTIONS_PER_MINUTE,
             icon=ICON_FAN,
@@ -94,12 +105,6 @@ CONFIG_SCHEMA = (
             state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional(CONF_OUTSIDE_TEMP): TEMPERATURE_SENSOR_SCHEMA,
-        cv.Optional(CONF_POWER_CONSUMPTION): sensor.sensor_schema(
-            unit_of_measurement=UNIT_KILOWATT_HOURS,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_ENERGY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
         cv.Optional(CONF_SETPOINT_TEMP): TEMPERATURE_SENSOR_SCHEMA,
         cv.Optional(CONF_SWING_VERTICAL_ANGLE): sensor.sensor_schema(
             unit_of_measurement=UNIT_DEGREES,
@@ -120,13 +125,15 @@ async def to_code(config):
         (CONF_COIL_TEMP, var.set_temp_coil_sensor),
         (CONF_COMPRESSOR_FREQUENCY, var.set_compressor_frequency_sensor),
         (CONF_DEMAND, var.set_demand_sensor),
+        (CONF_ENERGY_COOLING, var.set_energy_cooling_sensor),
+        (CONF_ENERGY_HEATING, var.set_energy_heating_sensor),
+        (CONF_ENERGY_INDOOR, var.set_energy_indoor_sensor),
         (CONF_FAN_SPEED, var.set_fan_speed_sensor),
         (CONF_HUMIDITY, var.set_humidity_sensor),
         (CONF_IR_COUNTER, var.set_ir_counter_sensor),
         (CONF_INSIDE_TEMP, var.set_temp_inside_sensor),
         (CONF_OUTDOOR_CAPACITY, var.set_outdoor_capacity_sensor),
         (CONF_OUTSIDE_TEMP, var.set_temp_outside_sensor),
-        (CONF_POWER_CONSUMPTION, var.set_power_consumption_sensor),
         (CONF_SETPOINT_TEMP, var.set_temp_setpoint_sensor),
         (CONF_SWING_VERTICAL_ANGLE, var.set_swing_vertical_angle_sensor),
         (CONF_TARGET_TEMPERATURE, var.set_temp_target_sensor),

--- a/components/daikin_s21/sensor/daikin_s21_sensor.cpp
+++ b/components/daikin_s21/sensor/daikin_s21_sensor.cpp
@@ -36,6 +36,9 @@ void DaikinS21Sensor::update() {
 }
 
 void DaikinS21Sensor::dump_config() {
+  LOG_SENSOR("", "Energy Cooling", this->energy_cooling_sensor_);
+  LOG_SENSOR("", "Energy Heating", this->energy_heating_sensor_);
+  LOG_SENSOR("", "Energy Indoor", this->energy_indoor_sensor_);
   LOG_SENSOR("", "Temperature Setpoint", this->temp_setpoint_sensor_);
   LOG_SENSOR("", "Temperature Inside", this->temp_inside_sensor_);
   LOG_SENSOR("", "Temperature Target", this->temp_target_sensor_);
@@ -47,7 +50,6 @@ void DaikinS21Sensor::dump_config() {
   LOG_SENSOR("", "Humidity", this->humidity_sensor_);
   LOG_SENSOR("", "Demand", this->demand_sensor_);
   LOG_SENSOR("", "IR Counter", this->ir_counter_sensor_);
-  LOG_SENSOR("", "Power Consumption", this->power_consumption_sensor_);
   LOG_SENSOR("", "Outdoor Capacity", this->outdoor_capacity_sensor_);
 }
 
@@ -55,6 +57,15 @@ void DaikinS21Sensor::dump_config() {
  * Unconditionally publish the sensors
  */
 void DaikinS21Sensor::publish_sensors() {
+  if (this->energy_cooling_sensor_ != nullptr) {
+    this->energy_cooling_sensor_->publish_state(this->get_parent()->get_energy_consumption_cooling() / 100.0F);
+  }
+  if (this->energy_heating_sensor_ != nullptr) {
+    this->energy_heating_sensor_->publish_state(this->get_parent()->get_energy_consumption_heating() / 100.0F);
+  }
+  if (this->energy_indoor_sensor_ != nullptr) {
+    this->energy_indoor_sensor_->publish_state(this->get_parent()->get_energy_consumption_indoor_units() / 100.0F);
+  }
   if (this->temp_setpoint_sensor_ != nullptr) {
     this->temp_setpoint_sensor_->publish_state(this->get_parent()->get_temp_setpoint().f_degc());
   }
@@ -87,9 +98,6 @@ void DaikinS21Sensor::publish_sensors() {
   }
   if (this->ir_counter_sensor_ != nullptr) {
     this->ir_counter_sensor_->publish_state(this->get_parent()->get_ir_counter());
-  }
-  if (this->power_consumption_sensor_ != nullptr) {
-    this->power_consumption_sensor_->publish_state(this->get_parent()->get_power_consumption() / 100.0F);
   }
   if (this->outdoor_capacity_sensor_ != nullptr) {
     this->outdoor_capacity_sensor_->publish_state(this->get_parent()->get_outdoor_capacity());

--- a/components/daikin_s21/sensor/daikin_s21_sensor.h
+++ b/components/daikin_s21/sensor/daikin_s21_sensor.h
@@ -18,6 +18,18 @@ class DaikinS21Sensor : public PollingComponent,
 
   void publish_sensors();
 
+  void set_energy_cooling_sensor(sensor::Sensor * const sensor) {
+    this->energy_cooling_sensor_ = sensor;
+    this->get_parent()->request_readout(DaikinS21::ReadoutEnergyConsumptionClimateModes);
+  }
+  void set_energy_heating_sensor(sensor::Sensor * const sensor) {
+    this->energy_heating_sensor_ = sensor;
+    this->get_parent()->request_readout(DaikinS21::ReadoutEnergyConsumptionClimateModes);
+  }
+  void set_energy_indoor_sensor(sensor::Sensor * const sensor) {
+    this->energy_indoor_sensor_ = sensor;
+    this->get_parent()->request_readout(DaikinS21::ReadoutEnergyConsumptionIndoorUnits);
+  }
   void set_temp_setpoint_sensor(sensor::Sensor * const sensor) {
     this->temp_setpoint_sensor_ = sensor;
   }
@@ -60,10 +72,6 @@ class DaikinS21Sensor : public PollingComponent,
     this->ir_counter_sensor_ = sensor;
     this->get_parent()->request_readout(DaikinS21::ReadoutIRCounter);
   }
-  void set_power_consumption_sensor(sensor::Sensor * const sensor) {
-    this->power_consumption_sensor_ = sensor;
-    this->get_parent()->request_readout(DaikinS21::ReadoutPowerConsumption);
-  }
   void set_outdoor_capacity_sensor(sensor::Sensor * const sensor) {
     this->outdoor_capacity_sensor_ = sensor;
     this->get_parent()->request_readout(DaikinS21::ReadoutOutdoorCapacity);
@@ -72,6 +80,9 @@ class DaikinS21Sensor : public PollingComponent,
  protected:
   bool is_free_run() const { return this->get_update_interval() == 0; }
 
+  sensor::Sensor *energy_cooling_sensor_{};
+  sensor::Sensor *energy_heating_sensor_{};
+  sensor::Sensor *energy_indoor_sensor_{};
   sensor::Sensor *temp_setpoint_sensor_{};
   sensor::Sensor *temp_inside_sensor_{};
   sensor::Sensor *temp_target_sensor_{};
@@ -83,7 +94,6 @@ class DaikinS21Sensor : public PollingComponent,
   sensor::Sensor *humidity_sensor_{};
   sensor::Sensor *demand_sensor_{};
   sensor::Sensor *ir_counter_sensor_{};
-  sensor::Sensor *power_consumption_sensor_{};
   sensor::Sensor *outdoor_capacity_sensor_{};
 };
 


### PR DESCRIPTION
Rename existing power_consumption sensor to energy_indoor.

Resolves #130 