### PR TITLE
Fix compressor frequency readout and units

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,16 @@ A big thanks to:
 A short changelog of sorts, I'll keep things here where a user might encounter
 breaking or significant changes.
 
+* Fixed compressor frequency sensor scaling. Please purge your history for this
+  sensor, the values will be incorrect.
 * Added additional energy consumption sensors for protocol 3.20+. Renamed
   existing "power_consumption" to "energy". Sorry. Update your YAML.
-* Checksum calculation was fixed. There's a faint chance that a command that was
-  previously NAK'd actually now works.
+* Checksum calculation was fixed. There's a faint chance that a command or
+  query that was previously NAK'd actually now works.
 * Custom Silent fan mode changed to standard Quiet. Custom Automatic was also
   updated to standard Auto to work around a validation issue, which results in
   a nicer icon. Update any automations to specify these new mode settings.
-* Configuration schema for the climate component (specidically the unit
+* Configuration schema for the climate component (specifically the unit
   temperature range limits) has changed to organize them by mode as well as
   adding a temperature offset to be applied when commanding the unit. Update
   your configurations to the new schema (see example) if your project now fails
@@ -494,13 +496,12 @@ sensor:
       filters:
         - delta: 0.0
     compressor_frequency:
-      name: Compressor Frequency  # RPM by default, uncomment below to map to Hz
+      name: Compressor Frequency
       device_id: daikin_outdoor
-      # unit_of_measurement: "Hz"
-      # device_class: frequency
-      # accuracy_decimals: 2
+      # unit_of_measurement: "RPM"  # if you would prefer RPM, uncomment the following
+      # device_class: ""  # override default "frequency", RPM is not a measurement of frequency in HA
       filters:
-        # - multiply: !lambda return 1.0F / 60.0F;
+        # - multiply: 60.0
         - delta: 0.0
     humidity:
       id: daikin_humidity

--- a/components/daikin_s21/s21.cpp
+++ b/components/daikin_s21/s21.cpp
@@ -1099,9 +1099,9 @@ void DaikinS21::handle_env_indoor_frequency_command_signal(const std::span<const
 }
 
 void DaikinS21::handle_env_compressor_frequency(const std::span<const uint8_t> payload) {
-  this->compressor_rpm = bytes_to_num(payload) * 10;
-  if (this->compressor_rpm == 9990) {
-    this->compressor_rpm = 0;  // reported by danijelt
+  this->compressor_hz = bytes_to_num(payload);
+  if (this->compressor_hz == 999) {
+    this->compressor_hz = 0;  // reported by danijelt
   }
 }
 

--- a/components/daikin_s21/s21.h
+++ b/components/daikin_s21/s21.h
@@ -90,7 +90,7 @@ class DaikinS21 : public PollingComponent {
   auto get_energy_consumption_heating() const { return this->energy_consumption_heating; }
   auto get_vertical_swing_mode() const { return this->vertical_swing_mode.value(); }
   auto get_outdoor_capacity() const { return this->outdoor_capacity; }
-  auto get_compressor_frequency() const { return this->compressor_rpm; }
+  auto get_compressor_frequency() const { return this->compressor_hz; }
   auto get_humidity() const { return this->humidity; }
   auto get_demand_pull() const { return this->demand_pull; }
   auto get_unit_state() const { return this->unit_state; }
@@ -205,7 +205,7 @@ class DaikinS21 : public PollingComponent {
   DaikinC10 temp_coil{};
   uint16_t fan_rpm_setpoint{};  // not supported
   uint16_t fan_rpm{};
-  uint16_t compressor_rpm{};
+  uint16_t compressor_hz{};
   int16_t swing_vertical_angle_setpoint{};  // not supported
   int16_t swing_vertical_angle{};
   uint16_t ir_counter{};

--- a/components/daikin_s21/sensor/__init__.py
+++ b/components/daikin_s21/sensor/__init__.py
@@ -11,6 +11,7 @@ from esphome.const import (
     CONF_ID,
     CONF_TARGET_TEMPERATURE,
     DEVICE_CLASS_ENERGY,
+    DEVICE_CLASS_FREQUENCY,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_TEMPERATURE,
     ICON_COUNTER,
@@ -20,6 +21,7 @@ from esphome.const import (
     STATE_CLASS_TOTAL_INCREASING,
     UNIT_CELSIUS,
     UNIT_DEGREES,
+    UNIT_HERTZ,
     UNIT_KILOWATT_HOURS,
     UNIT_PERCENT,
     UNIT_REVOLUTIONS_PER_MINUTE,
@@ -68,9 +70,10 @@ CONFIG_SCHEMA = (
     .extend({
         cv.Optional(CONF_COIL_TEMP): TEMPERATURE_SENSOR_SCHEMA,
         cv.Optional(CONF_COMPRESSOR_FREQUENCY): sensor.sensor_schema(
-            unit_of_measurement=UNIT_REVOLUTIONS_PER_MINUTE,
+            unit_of_measurement=UNIT_HERTZ,
             icon="mdi:pump",
             accuracy_decimals=0,
+            device_class=DEVICE_CLASS_FREQUENCY,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional(CONF_DEMAND): sensor.sensor_schema(


### PR DESCRIPTION
- DEVICE_CLASS_FREQUENCY, UNITS_HERTZ and values should be correct
- Update example to provide a conversion to RPM if desired, but hertz is what we get from the unit
- Hopefully the last time I touch this one

Fixes: #129