### PR TITLE
Remove STATE_CLASS_TOTAL_INCREASING from energy sensors

### DIFF
--- a/components/daikin_s21/sensor/__init__.py
+++ b/components/daikin_s21/sensor/__init__.py
@@ -18,7 +18,6 @@ from esphome.const import (
     ICON_FAN,
     ICON_WATER_PERCENT,
     STATE_CLASS_MEASUREMENT,
-    STATE_CLASS_TOTAL_INCREASING,
     UNIT_CELSIUS,
     UNIT_DEGREES,
     UNIT_HERTZ,
@@ -59,7 +58,7 @@ ENERGY_SENSOR_SCHEMA = sensor.sensor_schema(
     unit_of_measurement=UNIT_KILOWATT_HOURS,
     accuracy_decimals=1,
     device_class=DEVICE_CLASS_ENERGY,
-    state_class=STATE_CLASS_TOTAL_INCREASING,
+    state_class=STATE_CLASS_MEASUREMENT,
 )
 
 CONFIG_SCHEMA = (


### PR DESCRIPTION
We are disconnected from Daikin saving this value internally and power outages will resume from the last reported value. In the window of time after the save and before the power outage, we could have reported a higher value to Home Assistant. When power is restored, we resume reporting starting from the last saved value, triggering the meter rollover handling in HA. I don't see an easy way around this at the ESPHome level. Higher level logic in HA will have to account for this.

Fixes #130 