### PR TITLE
Fix compilation on 2026.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ESPHome component to control Daikin indoor mini-split units using the wired
 protocol available over S21 and related ports.
 
-**==Upgrade Note==**: If your automatic update failed, I may have changed some
+***Upgrade Note***: If your automatic update failed, I may have changed some
 config schema. I try not to do this but this project is still evolving. Please
 see the changelog below for details.
 
@@ -115,7 +115,7 @@ on a measured reference value.
 ### Select
 
 * Vertical swing setpoint. v2+ may support this. Preset values can be selected
-  for the vertical louvre, including the standard on and off for the varrying
+  for the vertical louver, including the standard on and off for the varrying
   setting.
 
 * Humidity setpoint. v2+ may support this. The operation of this isn't well
@@ -172,7 +172,7 @@ example configuration.
   not the user setpoint and not that interesting to me but may be useful for
   your automations.
 * Fan speed of inside blower.
-* Vertical swing angle of louvre. This uses Daikin's reference frame.
+* Vertical swing angle of louver. This uses Daikin's reference frame.
 * Compressor frequency of the outside exchanger.
 * Humidity. Not supported on all units, can report a consistent 50% or 0% if
   not present.
@@ -183,12 +183,12 @@ v2+ protocol units may also support:
 * IR counter that increments when the remote is used.
 * Energy consumption of all indoor units in kWh.
 * Outdoor unit capacity in indoor units.
-* Instantaneous unit power consumption in W. If you have a multihead system,
-  sampling jitter may result in incorrect results when summed. Use as a rough
-  indicator only and prefer energy consumption for your dashboard.
 
 v3.20+ protocol units may also support:
 
+* Instantaneous unit power consumption in W. If you have a multihead system,
+  sampling jitter may result in incorrect results when summed. Use as a rough
+  indicator only and prefer energy consumption for your dashboard.
 * Energy consumption in cooling and heating modes in kWh, including the outside
   unit's use, for this inside unit.
 
@@ -391,7 +391,7 @@ The default is 1.0°C to match Daikin's internal granularity.
 
 ```yaml
 esphome:
-  min_version: "2025.12"
+  min_version: "2026.1"
   devices:
     - id: daikin_outdoor
       name: "Daikin Compressor"
@@ -537,12 +537,11 @@ sensor:
       device_id: daikin_outdoor
       filters:
         - delta: 0.0
-    # Protocol Version 3
+    # Protocol Version 3.20:
     power:
       name: Unit Power
       filters:
         - delta: 0.0
-    # Protocol Version 3.20:
     energy_cooling:
       name: Energy Consumption Cooling
       filters:

--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -41,23 +41,23 @@ void DaikinS21Climate::setup() {
   this->heat_params.target_pref = global_preferences->make_preference<int16_t>(h + 3);
   // populate default traits
   this->traits_.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE | climate::CLIMATE_SUPPORTS_ACTION);
-  if (this->visual_min_temperature_override_.has_value()) {
-    this->traits_.set_visual_min_temperature(this->visual_min_temperature_override_.value());
+  if (std::isfinite(this->visual_min_temperature_override_)) {
+    this->traits_.set_visual_min_temperature(this->visual_min_temperature_override_);
   } else {
     this->traits_.set_visual_min_temperature(std::min({this->heat_cool_params.min, this->cool_params.min, this->heat_params.min}).f_degc());
   }
-  if (this->visual_max_temperature_override_.has_value()) {
-    this->traits_.set_visual_max_temperature(this->visual_max_temperature_override_.value());
+  if (std::isfinite(this->visual_max_temperature_override_)) {
+    this->traits_.set_visual_max_temperature(this->visual_max_temperature_override_);
   } else {
     this->traits_.set_visual_max_temperature(std::max({this->heat_cool_params.max, this->cool_params.max, this->heat_params.max}).f_degc());
   }
-  if (this->visual_target_temperature_step_override_.has_value()) {
-    this->traits_.set_visual_target_temperature_step(this->visual_target_temperature_step_override_.value());
+  if (std::isfinite(this->visual_target_temperature_step_override_)) {
+    this->traits_.set_visual_target_temperature_step(this->visual_target_temperature_step_override_);
   } else {
     this->traits_.set_visual_target_temperature_step(SETPOINT_STEP.f_degc());
   }
-  if (this->visual_current_temperature_step_override_.has_value()) {
-    this->traits_.set_visual_current_temperature_step(this->visual_current_temperature_step_override_.value());
+  if (std::isfinite(this->visual_current_temperature_step_override_)) {
+    this->traits_.set_visual_current_temperature_step(this->visual_current_temperature_step_override_);
   } else {
     this->traits_.set_visual_current_temperature_step(TEMPERATURE_STEP.f_degc());
   }
@@ -195,10 +195,10 @@ void DaikinS21Climate::dump_config() {
   ESP_LOGCONFIG(TAG, "  Setpoint interval: %" PRIu32 "s", this->get_update_interval() / 1000);
   for (const climate::ClimateMode mode : {climate::CLIMATE_MODE_HEAT_COOL, climate::CLIMATE_MODE_COOL, climate::CLIMATE_MODE_HEAT}) {
     if (const auto * const params = get_setpoint_mode_params(mode)) {
-      ESP_LOGCONFIG(TAG, "  %s unit setpoint range: %.1f-%.1f",
-          LOG_STR_ARG(climate::climate_mode_to_string(mode)), params->min.f_degc(), params->max.f_degc());
-      ESP_LOGCONFIG(TAG, "  %s user offset: %+.1f",
-          LOG_STR_ARG(climate::climate_mode_to_string(mode)), params->offset.f_degc());
+      ESP_LOGCONFIG(TAG, "  %s parameters\n"
+                         "    Unit setpoint range: %.1f-%.1f\n"
+                         "    User offset: %+.1f",
+          LOG_STR_ARG(climate::climate_mode_to_string(mode)), params->min.f_degc(), params->max.f_degc(), params->offset.f_degc());
     }
   }
   this->dump_traits_(TAG);
@@ -400,7 +400,7 @@ DaikinFanMode DaikinS21Climate::get_daikin_fan_mode() const {
       return DaikinFanAuto;
     }
   } else {
-    return string_to_daikin_fan_mode(this->get_custom_fan_mode());
+    return stringref_to_daikin_fan_mode(this->get_custom_fan_mode());
   }
 }
 

--- a/components/daikin_s21/daikin_s21_queries.h
+++ b/components/daikin_s21/daikin_s21_queries.h
@@ -84,7 +84,7 @@ namespace EnvironmentQuery {
   inline constexpr std::string_view LiquidTemperature{"RI"};
   inline constexpr std::string_view FanSpeedSetpoint{"RK"};
   inline constexpr std::string_view FanSpeed{"RL"};
-  inline constexpr std::string_view LouvreAngleSetpoint{"RM"};
+  inline constexpr std::string_view LouverAngleSetpoint{"RM"};
   inline constexpr std::string_view VerticalSwingAngle{"RN"};
   inline constexpr std::string_view RW{"RW"};
   inline constexpr std::string_view TargetTemperature{"RX"}; // (not user setpoint, see details)

--- a/components/daikin_s21/daikin_s21_types.h
+++ b/components/daikin_s21/daikin_s21_types.h
@@ -179,8 +179,8 @@ constexpr const char * daikin_fan_mode_to_cstr(const DaikinFanMode mode) {
   return std::get<const char *>(supported_daikin_fan_modes[mode]);
 }
 
-constexpr DaikinFanMode string_to_daikin_fan_mode(const std::string_view mode) {
-  const auto iter = std::ranges::find(supported_daikin_fan_modes, mode, [](const auto &elem){ return std::get<const char *>(elem); });
+constexpr DaikinFanMode stringref_to_daikin_fan_mode(const StringRef mode) {
+  const auto iter = std::ranges::find(supported_daikin_fan_modes, mode, [](const auto &elem){ return static_cast<StringRef>(std::get<const char *>(elem)); });
   if (iter != std::ranges::end(supported_daikin_fan_modes)) {
     return static_cast<DaikinFanMode>(std::ranges::distance(std::begin(supported_daikin_fan_modes), iter));
   }


### PR DESCRIPTION
- Bump minimum ESPHome version
- Fix Github's markdown flavour
- Fix some typos
- Move power sensor to Protocol v3.20 section
- Concatenate multiple logging statements per ESPHome's best practices
- Use StringRef for fan mode lookup, avoid conversion to string_view