### PR TITLE
reduce-mqtt-publish

### DIFF
--- a/components/daikin_s21/climate/__init__.py
+++ b/components/daikin_s21/climate/__init__.py
@@ -22,6 +22,8 @@ from .. import (
     CONF_S21_ID,
     S21_PARENT_SCHEMA,
 )
+CONF_TEMPERATURE_DEADBAND = "temperature_deadband"
+CONF_TEMPERATURE_PUBLISH_HOLDOFF = "temperature_publish_holdoff"
 
 AUTO_LOAD = ["sensor"]
 
@@ -56,6 +58,8 @@ CONFIG_SCHEMA = (
         cv.Optional(CONF_HEAT_COOL_MODE, default={}): CONFIG_MODE_SCHEMA,
         cv.Optional(CONF_COOL_MODE, default={CONF_MAX_TEMPERATURE:"32", CONF_MIN_TEMPERATURE:"18"}): CONFIG_MODE_SCHEMA,
         cv.Optional(CONF_HEAT_MODE, default={CONF_MAX_TEMPERATURE:"30", CONF_MIN_TEMPERATURE:"10"}): CONFIG_MODE_SCHEMA,
+        cv.Optional(CONF_TEMPERATURE_DEADBAND, default=0.3): cv.float_,
+        cv.Optional(CONF_TEMPERATURE_PUBLISH_HOLDOFF, default="30s"): cv.positive_time_period_milliseconds,
     })
 )
 
@@ -63,6 +67,10 @@ async def to_code(config):
     var = await climate.new_climate(config)
     await cg.register_component(var, config)
     await cg.register_parented(var, config[CONF_S21_ID])
+    cg.add(var.set_temperature_deadband(config[CONF_TEMPERATURE_DEADBAND]))
+    cg.add(var.set_temperature_publish_holdoff(
+        config[CONF_TEMPERATURE_PUBLISH_HOLDOFF].total_milliseconds
+    ))
 
     if CONF_SENSOR in config:
         sens = await cg.get_variable(config[CONF_SENSOR])

--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -10,8 +10,6 @@ using namespace esphome;
 namespace esphome::daikin_s21 {
 
 static const char * const TAG = "daikin_s21.climate";
-static constexpr uint32_t MIN_PUBLISH_INTERVAL = 10000; // 10sec
-static constexpr float TEMPERATURE_DEADBAND = 0.3; //Temperature deadband to preventfrequent updates
 
 /**
  * Save target for the mode to persistent storage.
@@ -110,7 +108,7 @@ void DaikinS21Climate::loop() {
   const float current_humidity = this->get_current_humidity();
   if ((this->mode != reported_climate.mode) ||
       (this->action != this->get_parent()->get_climate_action()) ||
-      (std::isnan(this->current_temperature) != std::isnan(current_temperature)) || (abs(this->current_temperature - current_temperature)>=TEMPERATURE_DEADBAND) || // differ in nan-ness or value
+      (std::isnan(this->current_temperature) != std::isnan(current_temperature)) || (abs(this->current_temperature - current_temperature) >= this->temperature_deadband_) || // differ in nan-ness or value
       (std::isnan(this->current_humidity) != std::isnan(current_humidity)) || (this->current_humidity != current_humidity) ||
       (this->swing_mode != reported_swing)) {
     this->mode = reported_climate.mode;
@@ -172,14 +170,25 @@ void DaikinS21Climate::loop() {
     }
   }
 
-  // Publish when state changed
   if (do_publish) {
     const uint32_t now = millis();
 
-    // Rate limit how often the state is published
-    if (MIN_PUBLISH_INTERVAL == 0 || now - this->last_publish_ >= MIN_PUBLISH_INTERVAL) {
+    const bool temperature_only =
+        (this->mode == reported_climate.mode) &&
+        (this->action == this->get_parent()->get_climate_action()) &&
+        (this->swing_mode == reported_swing);
+
+    if (!temperature_only) {
+      // Immediate publish for mode/fan/swing/action changes
       this->last_publish_ = now;
       this->publish_state();
+    } else {
+      // Temperature-only change → apply holdoff
+      if (this->temperature_publish_holdoff_ == 0 ||
+          now - this->last_publish_ >= this->temperature_publish_holdoff_) {
+        this->last_publish_ = now;
+        this->publish_state();
+      }
     }
   }
   // Command unit when setpoint changed
@@ -270,6 +279,14 @@ bool DaikinS21Climate::temperature_sensor_unit_is_valid() {
     return u == "°C" || u == "°F";
   }
   return false;
+}
+
+void DaikinS21Climate::set_temperature_deadband(float value) {
+  this->temperature_deadband_ = value;
+}
+
+void DaikinS21Climate::set_temperature_publish_holdoff(uint32_t value) {
+  this->temperature_publish_holdoff_ = value;
 }
 
 bool DaikinS21Climate::use_temperature_sensor() {

--- a/components/daikin_s21/climate/daikin_s21_climate.h
+++ b/components/daikin_s21/climate/daikin_s21_climate.h
@@ -35,12 +35,19 @@ class DaikinS21Climate : public climate::Climate,
   void set_temperature_reference_sensor(sensor::Sensor * const sensor) { this->temperature_sensor_ = sensor; }
   void set_humidity_reference_sensor(sensor::Sensor * sensor);
   void set_setpoint_mode_config(climate::ClimateMode mode, DaikinC10 offset, DaikinC10 min, DaikinC10 max);
+  void set_temperature_deadband(float value);
+  void set_temperature_publish_holdoff(uint32_t value);
 
  protected:
   climate::ClimateTraits traits_{};
   climate::ClimateTraits traits() override { return traits_; };
+
+  float temperature_deadband_{0.3f};        // default
+  uint32_t temperature_publish_holdoff_{30000};  // default 30s
+
   uint32_t last_publish_{0}; //Used for publish rate-limit when values fluctuate
   float last_temp_raw_{NAN}; //last measured inside temperature, used for denoise before rounding
+
 
   bool is_free_run() const { return this->get_update_interval() == 0; }
   bool temperature_sensor_unit_is_valid();

--- a/components/daikin_s21/climate/daikin_s21_climate.h
+++ b/components/daikin_s21/climate/daikin_s21_climate.h
@@ -39,6 +39,8 @@ class DaikinS21Climate : public climate::Climate,
  protected:
   climate::ClimateTraits traits_{};
   climate::ClimateTraits traits() override { return traits_; };
+  uint32_t last_publish_{0}; //Used for publish rate-limit when values fluctuate
+  float last_temp_raw_{NAN}; //last measured inside temperature, used for denoise before rounding
 
   bool is_free_run() const { return this->get_update_interval() == 0; }
   bool temperature_sensor_unit_is_valid();


### PR DESCRIPTION
I use the component from some time now and it is great. Recently I noticed it that if the inside temperature is on the edge of a degree it sends alot of updates. As of nature of climate component it sends its whole state just because temperature is flapping between 20 and 21 for example. Sometimes on every other read. 

I implemented a ratelimit in case something is faulty or just noisy it limits the publication rate to once every 10 seconds. 
Also the temperature is considered as changed if there is as least 0.3 degrees change. 