### PR TITLE
unit_of_measurement of sensor.sensor_schema should be UNIT_PERCENT

### DIFF
--- a/components/daikin_s21/sensor/__init__.py
+++ b/components/daikin_s21/sensor/__init__.py
@@ -94,7 +94,8 @@ CONFIG_SCHEMA = (
             state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional(CONF_HUMIDITY): sensor.sensor_schema(
-            unit_of_measurement=ICON_WATER_PERCENT,
+            unit_of_measurement=UNIT_PERCENT,
+            icon=ICON_WATER_PERCENT,
             accuracy_decimals=0,
             device_class=DEVICE_CLASS_HUMIDITY,
             state_class=STATE_CLASS_MEASUREMENT,


### PR DESCRIPTION
In components/daikin_s21/sensor/__init__.py, for CONF_HUMIDITY, unit_of_measurement should be UNIT_PERCENT, and ICON_WATER_PERCENT would be definition of icon.