### PR TITLE
Allow specifying the update rate of the climate sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Arduino.
 
 ## Hardware
 
-Please see the Faikout [wiring](https://github.com/revk/ESP32-Faikout/wiki/Wiring)
+Please see the Faikout [wiring](https://codeberg.org/RevK/ESP32-Faikout/wiki/Wiring)
 page for detailed documentation including pinouts, alternate connectors with
 images. The below is just a quick reference overview.
 
@@ -350,7 +350,7 @@ Contacts: JST `SXA-001T-P0.6`
 
 ### PCB Option 1
 
-joshbenner uses the board designed by revk available [here](https://github.com/revk/ESP32-Faikout/tree/main/PCB/Faikout).
+joshbenner uses the board designed by revk available [here](https://codeberg.org/RevK/ESP32-Faikout/src/branch/main/PCB/Faikout).
 Note that revk's design includes a FET that inverts the logic levels on the
 ESP's RX pin, and on newer revisions the TX pin as well. When interfacing
 through a FET the RX line should be configured with a pullup. This handling

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ config schema. I try not to do this but this project is still evolving. Please
 see the changelog below for details.
 
 A big thanks to:
-* [revk](https://github.com/revk) for work on the fantastic
-  [Faikout](https://github.com/revk/ESP32-Faikout) (née Faikin) project, which
+* [revk](https://codeberg.org/RevK) for work on the fantastic
+  [Faikout](https://codeberg.org/RevK/ESP32-Faikout) (née Faikin) project, which
   was the primary inspiration and guide for building this ESPHome component. In
   addition, the very active and resourceful community that project has fostered
   that has decoded much of the protocol.
@@ -24,13 +24,22 @@ A big thanks to:
 ## Recent / Breaking Changes
 
 A short changelog of sorts, I'll keep things here where a user might encounter
-breaking or significant changes.
+breaking or significant changes, including configuration updates.
 
+* ***Important***: Updated configuration schema of climate component. The
+  previous `update_interval` is moved to `offset_interval`. This is the period
+  where the external reference temperature sensor offset is applied to the
+  internal control loop. `update_interval` now means the period at which sensor
+  updates are published to the frontend. This addresses a user request to limit
+  the publishing rate when the system uses noisy or precise sensors with a high
+  update rate that aren't actually that interesting. Changes to other values
+  (action, fan mode, etc.) will still be published immediately. It can be
+  omitted for free run operation if desired.
 * Added instantaneous unit power sensor.
 * Fixed compressor frequency sensor scaling. Please purge your history for this
   sensor, the values will be incorrect.
 * Added additional energy consumption sensors for protocol 3.20+. Renamed
-  existing "power_consumption" to "energy_indoor" (briefly) to "energy". Sorry.
+  existing `power_consumption` to `energy_indoor` (briefly) to `energy`. Sorry.
   Update your YAML.
 * Checksum calculation was fixed. There's a faint chance that a command or
   query that was previously NAK'd actually now works.
@@ -261,12 +270,13 @@ details if you want a sensor or control added.
 
 ## Limitations
 
-**NOTE:** Currently there's a serious issue when using the Arduino framework.
+**NOTE:** There was a serious issue when using the Arduino framework.
 If flashed OTA you may lose communication and require a physical reflashing
 (annoying if your board in inside your air handler). Please stick to the
 ESP-IDF PlatformIO framework for now (Arduino is an extra shim over the ESP-IDF
 SDK anyways). See the framework selection in the configuration example. As of
-this writing, independent UART pin inversion control also wasn't possible.
+this writing, independent UART pin inversion control also wasn't possible with
+Arduino.
 
 * Aforementioned S21 control limitations. Your unit may support a mode but
   support for controlling over S21 may not be there. See your model's
@@ -452,7 +462,7 @@ climate:
     #     target_temperature: 1
     #     current_temperature: 0.5
     # Settings from DaikinS21Climate:
-    # supported_modes:  # optional, restricts available modes. off is always supported.
+    # supported_modes:  # optional, restricts available climate modes. off is always supported.
     #   - heat_cool
     #   - cool
     #   - heat
@@ -462,13 +472,14 @@ climate:
     #   - horizontal
     #   - vertical
     #   - both
+    # update_interval: 1min # Interval used to limit sensor publishing rate
+    # offset_interval: 5min # Interval used to adjust the unit's setpoint using finer grained control
     # Optional sensors to use for temperature and humidity references
     sensor: daikin_temperature  # Internal, see indoor temperature sensor below
     # sensor: room_temp  # External, see homeassistant sensor below
     humidity_sensor: daikin_humidity  # Internal, see humidity sensor below
     # humidity_sensor: room_humidity  # External, see homeassistant sensor below
-    # or leave unconfigured if unsupported to omit reporting
-    # update_interval: 60s # Interval used to adjust the unit's setpoint using reference sensor
+    # or leave unconfigured if unsupported to omit humidity reporting
     # Mode specific temperature parameters:
     # heat_cool_mode:
     #   offset: 0           # offset to apply to unit setpoint in this mode

--- a/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.h
+++ b/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.h
@@ -17,9 +17,9 @@ class DaikinS21BinarySensorMode : public binary_sensor::BinarySensor {
 class DaikinS21BinarySensor : public Component,
                               public Parented<DaikinS21> {
  public:
-  void setup() override;
-  void loop() override;
-  void dump_config() override;
+  void setup() final;
+  void loop() final;
+  void dump_config() final;
 
   void set_mode_sensor(DaikinS21BinarySensorMode * const mode_sensor) {
     this->mode_sensors_[mode_sensor->mode] = mode_sensor;

--- a/components/daikin_s21/climate/__init__.py
+++ b/components/daikin_s21/climate/__init__.py
@@ -38,6 +38,8 @@ SUPPORTED_CLIMATE_MODES_OPTIONS = {
 
 validate_supported_climate_mode = cv.enum(SUPPORTED_CLIMATE_MODES_OPTIONS, upper=True)
 
+CONF_OFFSET_INTERVAL = "offset_interval"
+
 CONFIG_MODE_SCHEMA = cv.Schema({
     cv.Optional(CONF_OFFSET, default="0"): cv.temperature,
     cv.Optional(CONF_MAX_TEMPERATURE, default="30"): cv.temperature,
@@ -49,6 +51,7 @@ CONFIG_SCHEMA = (
     .extend(cv.polling_component_schema("0s"))
     .extend(S21_PARENT_SCHEMA)
     .extend({
+        cv.Optional(CONF_OFFSET_INTERVAL, default="5min"): cv.positive_time_period_milliseconds,
         cv.Optional(CONF_SENSOR): cv.use_id(sensor.Sensor),
         cv.Optional(CONF_HUMIDITY_SENSOR): cv.use_id(sensor.Sensor),
         cv.Optional(CONF_SUPPORTED_MODES, default=list(SUPPORTED_CLIMATE_MODES_OPTIONS)): cv.ensure_list(validate_supported_climate_mode),
@@ -63,6 +66,8 @@ async def to_code(config):
     var = await climate.new_climate(config)
     await cg.register_component(var, config)
     await cg.register_parented(var, config[CONF_S21_ID])
+
+    cg.add(var.set_offset_interval(config[CONF_OFFSET_INTERVAL]))
 
     if CONF_SENSOR in config:
         sens = await cg.get_variable(config[CONF_SENSOR])

--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -100,20 +100,20 @@ void DaikinS21Climate::setup() {
  * Publishes any state changes to Home Assistant.
  */
 void DaikinS21Climate::loop() {
+  const float new_humidity = this->get_current_humidity();
+  const DaikinC10 prev_temperature = this->current_temperature;
+  const DaikinC10 new_temperature = this->get_current_temperature();
   const auto reported_climate = this->get_parent()->get_climate();
   const auto reported_swing = this->get_parent()->get_swing_mode();
-  const float new_temperature = this->get_current_temperature().f_degc();
-  const float new_humidity = this->get_current_humidity();
-  bool do_publish = false;
-  bool update_unit_setpoint = false;
+  bool do_publish{};
+  bool update_unit_setpoint{};
 
   // See if there's a reason to publish an update
   // Temperature and humidity can be noisy, only publish because of them if the component update interval has passed
   if (this->check_sensors) {
-    if ((std::isfinite(this->current_temperature) != std::isfinite(new_temperature)) || // differ in finite-ness
-        (std::isfinite(this->current_temperature) && (this->current_temperature != new_temperature)) || // differ in finite value
-        (std::isfinite(this->current_humidity) != std::isfinite(new_humidity)) ||
-        (std::isfinite(this->current_humidity) && (this->current_humidity != new_humidity))) {
+    if ((prev_temperature != new_temperature) ||
+        (std::isfinite(this->current_humidity) != std::isfinite(new_humidity)) || // differ in finite-ness
+        (std::isfinite(this->current_humidity) && (this->current_humidity != new_humidity))) {  // differ in finite value
       do_publish = true;
     }
     this->check_sensors = this->is_free_run();
@@ -163,7 +163,7 @@ void DaikinS21Climate::loop() {
       this->next_offset_check_ms = App.get_loop_component_start_time() + this->offset_interval;
 
       // Reuse this flag to mean the setpoint has been updated and should be sent
-      update_unit_setpoint = this->calc_unit_setpoint();
+      update_unit_setpoint = this->calc_unit_setpoint(*mode_params, new_temperature);
     }
   } else {
     // Not a setpoint mode
@@ -182,7 +182,7 @@ void DaikinS21Climate::loop() {
     // Save local state so we know what was last published
     this->mode = reported_climate.mode;
     this->action = this->get_parent()->get_climate_action();
-    this->current_temperature = new_temperature;
+    this->current_temperature = new_temperature.f_degc();
     this->current_humidity = new_humidity;
     this->swing_mode = reported_swing;
     this->publish_state();
@@ -302,27 +302,23 @@ DaikinC10 DaikinS21Climate::get_current_temperature() {
 }
 
 /**
- * Determine the unit setpoint value based on the current temperature and target temperature.
+ * Determine the unit setpoint value based on the current temperature and target temperature for a given setpoint mode.
  *
  * Applies offsets from the external reference sensor and user correction if present.
  *
+ * @pre target_temperature is set
+ *
+ * @param mode_params the setpoint mode parameters to use
+ * @param current_temperature the current measured external temperature
  * @return true if the setpoint changed, false otherwise
  */
-bool DaikinS21Climate::calc_unit_setpoint() {
-  // First ensure we're in a setpoint mode
-  auto * const mode_params = this->get_setpoint_mode_params(this->mode);
-  if (mode_params == nullptr) {
-    this->unit_setpoint = TEMPERATURE_INVALID;
-    return false;
-  }
-
+bool DaikinS21Climate::calc_unit_setpoint(const DaikinSetpointMode& mode_params, const DaikinC10 current_temperature) {
   // Find the difference between the unit and reference sensor (0 if the same sensor)
-  const auto current_temperature = this->get_current_temperature();
   const auto unit_temperature = this->get_parent()->get_temp_inside();
   const auto sensor_offset = unit_temperature - current_temperature;
 
   // Find the ideal unit setpoint by applying the sensor and user correction offsets
-  auto new_unit_setpoint = static_cast<DaikinC10>(this->target_temperature) + sensor_offset + mode_params->offset;
+  auto new_unit_setpoint = static_cast<DaikinC10>(this->target_temperature) + sensor_offset + mode_params.offset;
 
   // Round to Daikin's internal setpoint resolution
   // When the ideal setpoint is between steps force it in the direction of change by controlling rounding. Over time it should oscillate over the ideal setpoint.
@@ -339,13 +335,13 @@ bool DaikinS21Climate::calc_unit_setpoint() {
   // Ensure it's valid for the unit's current mode.
   // Daikin will clamp internally with a slightly out of range value, but it's faster for the UI to do it here without waiting for comms
   // Also, when large offsets are used, the value can be so far out of range it will be NAK'd
-  new_unit_setpoint = std::clamp(new_unit_setpoint, mode_params->min, mode_params->max);
+  new_unit_setpoint = std::clamp(new_unit_setpoint, mode_params.min, mode_params.max);
 
   // Log results if changing
   const bool unit_setpoint_changed = (this->unit_setpoint != new_unit_setpoint);
   if (unit_setpoint_changed) {
     ESP_LOGI(TAG, "Unit setpoint recalculated: %.1f -> %.1f%+.1f%+.1f = %.1f",
-        this->unit_setpoint.f_degc(), this->target_temperature, sensor_offset.f_degc(), mode_params->offset.f_degc(), new_unit_setpoint.f_degc());
+        this->unit_setpoint.f_degc(), this->target_temperature, sensor_offset.f_degc(), mode_params.offset.f_degc(), new_unit_setpoint.f_degc());
     this->unit_setpoint = new_unit_setpoint;
   }
 
@@ -359,29 +355,38 @@ bool DaikinS21Climate::calc_unit_setpoint() {
  */
 void DaikinS21Climate::control(const climate::ClimateCall &call) {
   // DaikinClimateSettings changes
-  bool climate_changed = false;
+  bool climate_changed{};
+
   if (call.get_mode().has_value() && (this->mode != call.get_mode().value())) {
     this->mode = call.get_mode().value();
     climate_changed = true;
-    // If call sets the mode but does not include target, then try to use saved target.
-    if (call.get_target_temperature().has_value() == false) {
-      if (auto * const mode_params = this->get_setpoint_mode_params(this->mode)) {
-        const auto sp = mode_params->load_target();
-        if (sp != TEMPERATURE_INVALID) {
-          this->target_temperature = sp.f_degc();
-        }
-      } else {
-        this->target_temperature = NAN; // Clear setpoint if not in a setpoint mode
+  }
+  auto * const mode_params = this->get_setpoint_mode_params(this->mode);
+
+  // Target change is only relevant to the unit if it causes a setpoint change, track separately
+  bool target_changed{};
+  const DaikinC10 new_target = call.get_target_temperature().has_value() ? call.get_target_temperature().value() :  // Target provided
+                               (mode_params != nullptr) ? mode_params->load_target() :  // Try to use the saved target if call does not include it
+                               TEMPERATURE_INVALID;
+  if (this->target_temperature != new_target) {
+    this->target_temperature = new_target.f_degc();
+    target_changed = true;
+  }
+
+  // Check for unit setpoint change if mode or target changing
+  if (climate_changed || target_changed) {
+    if ((mode_params != nullptr) && std::isfinite(this->target_temperature)) {
+      if (this->calc_unit_setpoint(*mode_params, this->get_current_temperature())) {
+        climate_changed = true;
+      }
+    } else {
+      if (this->unit_setpoint != TEMPERATURE_INVALID) {
+        this->unit_setpoint = TEMPERATURE_INVALID;
+        climate_changed = true;
       }
     }
   }
-  if (call.get_target_temperature().has_value() && (this->target_temperature != call.get_target_temperature().value())) {
-    this->target_temperature = call.get_target_temperature().value();
-    climate_changed = true;
-  }
-  if (climate_changed) {
-    (void)this->calc_unit_setpoint();  // mode and target temperature required
-  }
+
   if (call.get_fan_mode().has_value()) {
     if (this->set_fan_mode_(call.get_fan_mode().value())) {
       climate_changed = true;
@@ -391,6 +396,7 @@ void DaikinS21Climate::control(const climate::ClimateCall &call) {
       climate_changed = true;
     }
   }
+
   if (climate_changed) {
     this->set_s21_climate();  // mode, unit setpoint and fan required
   }
@@ -461,10 +467,10 @@ DaikinSetpointMode* DaikinS21Climate::get_setpoint_mode_params(climate::ClimateM
       return &this->heat_cool_params;
       break;
     case climate::CLIMATE_MODE_COOL:
-    return &this->cool_params;
+      return &this->cool_params;
       break;
     case climate::CLIMATE_MODE_HEAT:
-    return &this->heat_params;
+      return &this->heat_params;
       break;
     default:
       return nullptr;

--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -1,9 +1,11 @@
 #include <cmath>
+#include "esphome/core/application.h"
 #include "esphome/core/defines.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 #include "daikin_s21_climate.h"
 #include "../s21.h"
+#include "../utils.h"
 
 using namespace esphome;
 
@@ -100,24 +102,26 @@ void DaikinS21Climate::setup() {
 void DaikinS21Climate::loop() {
   const auto reported_climate = this->get_parent()->get_climate();
   const auto reported_swing = this->get_parent()->get_swing_mode();
+  const float new_temperature = this->get_current_temperature().f_degc();
+  const float new_humidity = this->get_current_humidity();
   bool do_publish = false;
   bool update_unit_setpoint = false;
 
-  // If the reported state differs from the component state, update component and publish an update
-  const float new_temperature = this->get_current_temperature().f_degc();
-  const float new_humidity = this->get_current_humidity();
+  // See if there's a reason to publish an update
+  // Temperature and humidity can be noisy, only publish because of them if the component update interval has passed
+  if (this->check_sensors) {
+    if ((std::isfinite(this->current_temperature) != std::isfinite(new_temperature)) || // differ in finite-ness
+        (std::isfinite(this->current_temperature) && (this->current_temperature != new_temperature)) || // differ in finite value
+        (std::isfinite(this->current_humidity) != std::isfinite(new_humidity)) ||
+        (std::isfinite(this->current_humidity) && (this->current_humidity != new_humidity))) {
+      do_publish = true;
+    }
+    this->check_sensors = this->is_free_run();
+  }
+  // Always publish other changes
   if ((this->mode != reported_climate.mode) ||
       (this->action != this->get_parent()->get_climate_action()) ||
-      (std::isfinite(this->current_temperature) != std::isfinite(new_temperature)) || // differ in finite-ness
-      (std::isfinite(this->current_temperature) && (this->current_temperature != new_temperature)) || // differ in finite value
-      (std::isfinite(this->current_humidity) != std::isfinite(new_humidity)) ||
-      (std::isfinite(this->current_humidity) && (this->current_humidity != new_humidity)) ||
       (this->swing_mode != reported_swing)) {
-    this->mode = reported_climate.mode;
-    this->action = this->get_parent()->get_climate_action();
-    this->current_temperature = new_temperature;
-    this->current_humidity = new_humidity;
-    this->swing_mode = reported_swing;
     do_publish = true;
   }
   if (this->set_daikin_fan_mode(reported_climate.fan)) {
@@ -125,7 +129,7 @@ void DaikinS21Climate::loop() {
   }
 
   // Update target temperature (user's desire) and unit setpoint (after offset)
-  if (auto * const mode_params = this->get_setpoint_mode_params(this->mode)) {
+  if (auto * const mode_params = this->get_setpoint_mode_params(reported_climate.mode)) {
     // Initialize setpoint so chenge detection can work
     if (this->unit_setpoint == TEMPERATURE_INVALID) {
       this->unit_setpoint = reported_climate.setpoint;
@@ -155,8 +159,9 @@ void DaikinS21Climate::loop() {
     }
 
     // Recalculate the unit setpoint if the target temperature changed or it's time to recheck
-    if (update_unit_setpoint || this->is_free_run() || this->check_setpoint) {
-      this->check_setpoint = false;
+    if (update_unit_setpoint || timestamp_passed(App.get_loop_component_start_time(), this->next_offset_check_ms)) {
+      this->next_offset_check_ms = App.get_loop_component_start_time() + this->offset_interval;
+
       // Reuse this flag to mean the setpoint has been updated and should be sent
       update_unit_setpoint = this->calc_unit_setpoint();
     }
@@ -174,6 +179,12 @@ void DaikinS21Climate::loop() {
 
   // Publish when state changed
   if (do_publish) {
+    // Save local state so we know what was last published
+    this->mode = reported_climate.mode;
+    this->action = this->get_parent()->get_climate_action();
+    this->current_temperature = new_temperature;
+    this->current_humidity = new_humidity;
+    this->swing_mode = reported_swing;
     this->publish_state();
   }
   // Command unit when setpoint changed
@@ -191,7 +202,7 @@ void DaikinS21Climate::loop() {
  * when applicable in the current climate mode.
  */
 void DaikinS21Climate::update() {
-  this->check_setpoint = true;
+  this->check_sensors = true;
 }
 
 void DaikinS21Climate::dump_config() {

--- a/components/daikin_s21/climate/daikin_s21_climate.h
+++ b/components/daikin_s21/climate/daikin_s21_climate.h
@@ -24,11 +24,11 @@ class DaikinS21Climate : public climate::Climate,
                          public PollingComponent,
                          public Parented<DaikinS21> {
  public:
-  void setup() override;
-  void loop() override;
-  void update() override;
-  void dump_config() override;
-  void control(const climate::ClimateCall &call) override;
+  void setup() final;
+  void loop() final;
+  void update() final;
+  void dump_config() final;
+  void control(const climate::ClimateCall &call) final;
 
   void set_offset_interval(const uint32_t offset_interval) { this->offset_interval = offset_interval; };
   void set_supported_modes(climate::ClimateModeMask modes);
@@ -39,7 +39,7 @@ class DaikinS21Climate : public climate::Climate,
 
  protected:
   climate::ClimateTraits traits_{};
-  climate::ClimateTraits traits() override { return traits_; };
+  climate::ClimateTraits traits() final { return traits_; };
 
   bool is_free_run() const { return this->get_update_interval() == 0; }
   bool temperature_sensor_unit_is_valid();

--- a/components/daikin_s21/climate/daikin_s21_climate.h
+++ b/components/daikin_s21/climate/daikin_s21_climate.h
@@ -46,7 +46,7 @@ class DaikinS21Climate : public climate::Climate,
   bool use_temperature_sensor();
   DaikinC10 temperature_sensor_degc();
   DaikinC10 get_current_temperature();
-  bool calc_unit_setpoint();
+  bool calc_unit_setpoint(const DaikinSetpointMode &mode_params, DaikinC10 current_temperature);
   float get_current_humidity() const;
   DaikinFanMode get_daikin_fan_mode() const;
   bool set_daikin_fan_mode(DaikinFanMode fan);

--- a/components/daikin_s21/climate/daikin_s21_climate.h
+++ b/components/daikin_s21/climate/daikin_s21_climate.h
@@ -30,6 +30,7 @@ class DaikinS21Climate : public climate::Climate,
   void dump_config() override;
   void control(const climate::ClimateCall &call) override;
 
+  void set_offset_interval(const uint32_t offset_interval) { this->offset_interval = offset_interval; };
   void set_supported_modes(climate::ClimateModeMask modes);
   void set_supported_swing_modes(climate::ClimateSwingModeMask swing_modes);
   void set_temperature_reference_sensor(sensor::Sensor * const sensor) { this->temperature_sensor_ = sensor; }
@@ -53,8 +54,10 @@ class DaikinS21Climate : public climate::Climate,
 
   sensor::Sensor *temperature_sensor_{};
   sensor::Sensor *humidity_sensor_{};
+  uint32_t offset_interval{};
+  uint32_t next_offset_check_ms{};
   DaikinC10 unit_setpoint{TEMPERATURE_INVALID};
-  bool check_setpoint{};
+  bool check_sensors{true};
   bool target_resolved{};
 
   DaikinSetpointMode* get_setpoint_mode_params(climate::ClimateMode mode);

--- a/components/daikin_s21/daikin_s21_serial.h
+++ b/components/daikin_s21/daikin_s21_serial.h
@@ -28,9 +28,9 @@ class DaikinSerial : public Component,
 
   DaikinSerial(uart::UARTComponent * const uart) : uart(*uart) {}
 
-  void setup() override;
-  void loop() override;
-  void dump_config() override;
+  void setup() final;
+  void loop() final;
+  void dump_config() final;
   void set_debug(const bool set) { this->debug = set; }
 
   void send_frame(std::string_view cmd, std::span<const uint8_t> payload = {});

--- a/components/daikin_s21/number/daikin_s21_number.h
+++ b/components/daikin_s21/number/daikin_s21_number.h
@@ -11,15 +11,15 @@ namespace esphome::daikin_s21 {
 class DaikinS21NumberDemand : public number::Number,
                               public Parented<DaikinS21> {
  protected:
-  void control(float value) override;
+  void control(float value) final;
 };
 
 class DaikinS21Number : public Component,
                         public Parented<DaikinS21> {
  public:
-  void setup() override;
-  void loop() override;
-  void dump_config() override;
+  void setup() final;
+  void loop() final;
+  void dump_config() final;
 
   void set_demand(DaikinS21NumberDemand * const number) {
     this->demand_number_ = number;

--- a/components/daikin_s21/s21.cpp
+++ b/components/daikin_s21/s21.cpp
@@ -179,7 +179,7 @@ DaikinS21::DaikinS21(DaikinSerial * const serial)
   : serial(*serial) { // serial required in config, non-null
   // populate supported queries
   // this is done in the constructor so debug queries are only ever added to this list
-  // see https://github.com/revk/ESP32-Faikout/wiki/S21-Protocol for documentation
+  // see https://codeberg.org/RevK/ESP32-Faikout/wiki/S21-Protocol for documentation
   this->queries = {
     {StateQuery::Basic, &DaikinS21::handle_state_basic, 4},
     {StateQuery::OptionalFeatures, &DaikinS21::handle_nop, 4, true},

--- a/components/daikin_s21/s21.h
+++ b/components/daikin_s21/s21.h
@@ -18,10 +18,10 @@ class DaikinS21 : public PollingComponent {
  public:
   DaikinS21(DaikinSerial * const serial);
 
-  void setup() override;
-  void loop() override;
-  void update() override;
-  void dump_config() override;
+  void setup() final;
+  void loop() final;
+  void update() final;
+  void dump_config() final;
   void set_debug(const bool set) { this->debug = set; }
 
   // external command action

--- a/components/daikin_s21/select/daikin_s21_select.h
+++ b/components/daikin_s21/select/daikin_s21_select.h
@@ -10,27 +10,27 @@ namespace esphome::daikin_s21 {
 class DaikinS21SelectLEDBrightness : public select::Select,
                                      public Parented<DaikinS21> {
  protected:
-  void control(size_t index) override;
+  void control(size_t index) final;
 };
 
 class DaikinS21SelectHumidity : public select::Select,
                                 public Parented<DaikinS21> {
  protected:
-  void control(size_t index) override;
+  void control(size_t index) final;
 };
 
 class DaikinS21SelectVerticalSwing : public select::Select,
                                      public Parented<DaikinS21> {
  protected:
-  void control(size_t index) override;
+  void control(size_t index) final;
 };
 
 class DaikinS21Select : public Component,
                         public Parented<DaikinS21> {
  public:
-  void setup() override;
-  void loop() override;
-  void dump_config() override;
+  void setup() final;
+  void loop() final;
+  void dump_config() final;
 
   void set_brightness_select(DaikinS21SelectLEDBrightness * const brightness_select) {
     this->brightness_select_ = brightness_select;

--- a/components/daikin_s21/sensor/daikin_s21_sensor.h
+++ b/components/daikin_s21/sensor/daikin_s21_sensor.h
@@ -11,10 +11,10 @@ namespace esphome::daikin_s21 {
 class DaikinS21Sensor : public PollingComponent,
                         public Parented<DaikinS21> {
  public:
-  void setup() override;
-  void loop() override;
-  void update() override;
-  void dump_config() override;
+  void setup() final;
+  void loop() final;
+  void update() final;
+  void dump_config() final;
 
   void publish_sensors();
 

--- a/components/daikin_s21/switch/daikin_s21_switch.h
+++ b/components/daikin_s21/switch/daikin_s21_switch.h
@@ -11,7 +11,7 @@ namespace esphome::daikin_s21 {
 class DaikinS21SwitchMode : public switch_::Switch,
                             public Parented<DaikinS21> {
  protected:
-  void write_state(bool state) override;
+  void write_state(bool state) final;
  public:
   DaikinS21SwitchMode(const DaikinMode mode) : mode(mode) {}
   DaikinMode mode{};
@@ -20,9 +20,9 @@ class DaikinS21SwitchMode : public switch_::Switch,
 class DaikinS21Switch : public Component,
                         public Parented<DaikinS21> {
  public:
-  void setup() override;
-  void loop() override;
-  void dump_config() override;
+  void setup() final;
+  void loop() final;
+  void dump_config() final;
 
   void set_mode_switch(DaikinS21SwitchMode * const mode_switch) {
     this->mode_switches_[mode_switch->mode] = mode_switch;

--- a/components/daikin_s21/text_sensor/daikin_s21_text_sensor.h
+++ b/components/daikin_s21/text_sensor/daikin_s21_text_sensor.h
@@ -13,9 +13,9 @@ namespace esphome::daikin_s21 {
 class DaikinS21TextSensor : public Component,
                             public Parented<DaikinS21> {
  public:
-  void setup() override;
-  void loop() override;
-  void dump_config() override;
+  void setup() final;
+  void loop() final;
+  void dump_config() final;
 
   void set_model_sensor(text_sensor::TextSensor * const sensor) {
     this->model_sensor_ = sensor;


### PR DESCRIPTION
Modifies the config schema meaning for the climate component. This can
cause your climate update rate to slow if you were using an external
reference sensor. See readme for details.

* Update some Faikin links (they're still rebuilding their wiki)

Optimizations

* Use prefetched arguments for setpoint selection
* Use DaikinC10 temperature in climate updates
* Don't recalculate setpoint unnecessarily when target temperature is changing

Fixes #156