### PR TITLE
Fix issues with ESPHome 2026.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ A big thanks to:
 A short changelog of sorts, I'll keep things here where a user might encounter
 breaking or significant changes, including configuration updates.
 
+* Bumped minimum ESPHome version to 2026.4.0 in order to address a few issues.
+  If you have an `update_interval` of 0s specified in any polling components
+  (s21, climate, sensor) please change this to `never` to indicate the intent
+  to not poll. My code will treat this a request to free run and publish
+  updates when available. Improvements to ESPHome's scheduler mean 0s polls are
+  now honoured immediately and watchdog timeouts will occur. As of today
+  there's no warning or mitigation during codegen. My code will avoid these
+  lockups for now but in 2026.4.1 you'll see very tight polling loops until you
+  update your config, so update them now. At some point down the line I will
+  remove my local mitigation and ESPHome compile time warnings will serve.
+  See [15516](https://github.com/esphome/esphome/pull/15516) and [15799](https://github.com/esphome/esphome/pull/15799).
 * ***Important***: Updated configuration schema of climate component. The
   previous `update_interval` is moved to `offset_interval`. This is the period
   where the external reference temperature sensor offset is applied to the
@@ -418,7 +429,7 @@ The default is 1.0°C to match Daikin's internal granularity.
 
 ```yaml
 esphome:
-  min_version: "2026.1"
+  min_version: "2026.4.0"
   devices:
     - id: daikin_outdoor
       name: "Daikin Compressor"
@@ -450,7 +461,7 @@ uart:
 daikin_s21:
   uart: s21_uart
   # debug_protocol: true  # please enable when reporting logs!
-  # update_interval: 5s  # also supports periodic polling instead of more responsive free run
+  # update_interval: never  # Communication cycle rate, 'never' for free run
 
 climate:
   - name: My Daikin
@@ -472,8 +483,8 @@ climate:
     #   - horizontal
     #   - vertical
     #   - both
-    # update_interval: 1min # Interval used to limit sensor publishing rate
-    # offset_interval: 5min # Interval used to adjust the unit's setpoint using finer grained control
+    # update_interval: never # Interval used to limit sensor publishing rate, 'never' for free run
+    # offset_interval: 5min # Interval used to adjust the unit's setpoint using finer grained control, 'never' for free run
     # Optional sensors to use for temperature and humidity references
     sensor: daikin_temperature  # Internal, see indoor temperature sensor below
     # sensor: room_temp  # External, see homeassistant sensor below
@@ -505,7 +516,7 @@ select:
 
 sensor:
   - platform: daikin_s21
-    update_interval: 0s
+    # update_interval: never  # Publishing interval, 'never' for immediate updates but may be noisy if you don't use filters
     # setpoint_temperature: # Unit setpoint. provided for insight on climate adjustment but probably not useful for users.
     #   name: Setpoint Temperature
     #   filters:

--- a/components/daikin_s21/__init__.py
+++ b/components/daikin_s21/__init__.py
@@ -8,6 +8,7 @@ from esphome.const import (
   CONF_ID,
   CONF_LED,
   CONF_MOTION,
+  CONF_NEVER,
   ICON_ACCOUNT_CHECK,
 )
 
@@ -52,7 +53,7 @@ UARTComponent = uart_ns.class_("UARTComponent")
 CONFIG_SCHEMA = (
     cv.COMPONENT_SCHEMA
     .extend({cv.GenerateID(): cv.declare_id(DaikinS21)})
-    .extend(cv.polling_component_schema("0s"))
+    .extend(cv.polling_component_schema(CONF_NEVER))
     .extend({
       cv.GenerateID(CONF_DAIKIN_SERIAL_ID): cv.declare_id(DaikinSerial),
       cv.Required(CONF_UART): cv.use_id(UARTComponent),

--- a/components/daikin_s21/climate/__init__.py
+++ b/components/daikin_s21/climate/__init__.py
@@ -12,6 +12,7 @@ from esphome.const import (
     CONF_HUMIDITY_SENSOR,
     CONF_MAX_TEMPERATURE,
     CONF_MIN_TEMPERATURE,
+    CONF_NEVER,
     CONF_OFFSET,
     CONF_SENSOR,
     CONF_SUPPORTED_MODES,
@@ -48,17 +49,17 @@ CONFIG_MODE_SCHEMA = cv.Schema({
 
 CONFIG_SCHEMA = (
     climate.climate_schema(DaikinS21Climate)
-    .extend(cv.polling_component_schema("0s"))
+    .extend(cv.polling_component_schema(CONF_NEVER))
     .extend(S21_PARENT_SCHEMA)
     .extend({
-        cv.Optional(CONF_OFFSET_INTERVAL, default="5min"): cv.positive_time_period_milliseconds,
+        cv.Optional(CONF_OFFSET_INTERVAL, default="5min"): cv.update_interval,
         cv.Optional(CONF_SENSOR): cv.use_id(sensor.Sensor),
         cv.Optional(CONF_HUMIDITY_SENSOR): cv.use_id(sensor.Sensor),
         cv.Optional(CONF_SUPPORTED_MODES, default=list(SUPPORTED_CLIMATE_MODES_OPTIONS)): cv.ensure_list(validate_supported_climate_mode),
         cv.Optional(CONF_SUPPORTED_SWING_MODES, default=list(climate.CLIMATE_SWING_MODES)): cv.ensure_list(climate.validate_climate_swing_mode),
         cv.Optional(CONF_HEAT_COOL_MODE, default={}): CONFIG_MODE_SCHEMA,
-        cv.Optional(CONF_COOL_MODE, default={CONF_MAX_TEMPERATURE:"32", CONF_MIN_TEMPERATURE:"18"}): CONFIG_MODE_SCHEMA,
-        cv.Optional(CONF_HEAT_MODE, default={CONF_MAX_TEMPERATURE:"30", CONF_MIN_TEMPERATURE:"10"}): CONFIG_MODE_SCHEMA,
+        cv.Optional(CONF_COOL_MODE, default={CONF_MAX_TEMPERATURE:"32"}): CONFIG_MODE_SCHEMA,
+        cv.Optional(CONF_HEAT_MODE, default={CONF_MIN_TEMPERATURE:"10"}): CONFIG_MODE_SCHEMA,
     })
 )
 

--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -37,46 +37,25 @@ DaikinC10 DaikinSetpointMode::load_target() {
 }
 
 void DaikinS21Climate::setup() {
+  // mitigation, remove when 2026.4.1 released
+  if (this->get_update_interval() <= 1) {
+    this->set_update_interval(SCHEDULER_DONT_RUN);
+    this->stop_poller();
+  }
+
   uint32_t h = this->get_object_id_hash();
   this->heat_cool_params.target_pref = global_preferences->make_preference<int16_t>(h + 1);
   this->cool_params.target_pref = global_preferences->make_preference<int16_t>(h + 2);
   this->heat_params.target_pref = global_preferences->make_preference<int16_t>(h + 3);
   // populate default traits
   this->traits_.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE | climate::CLIMATE_SUPPORTS_ACTION);
-#ifdef USE_CLIMATE_VISUAL_OVERRIDES
-  if (std::isfinite(this->visual_min_temperature_override_)) {
-    this->traits_.set_visual_min_temperature(this->visual_min_temperature_override_);
-  } else
-#endif
-  {
-    this->traits_.set_visual_min_temperature(std::min({this->heat_cool_params.min, this->cool_params.min, this->heat_params.min}).f_degc());
-  }
-#ifdef USE_CLIMATE_VISUAL_OVERRIDES
-  if (std::isfinite(this->visual_max_temperature_override_)) {
-    this->traits_.set_visual_max_temperature(this->visual_max_temperature_override_);
-  } else
-#endif
-  {
-    this->traits_.set_visual_max_temperature(std::max({this->heat_cool_params.max, this->cool_params.max, this->heat_params.max}).f_degc());
-  }
-#ifdef USE_CLIMATE_VISUAL_OVERRIDES
-  if (std::isfinite(this->visual_target_temperature_step_override_)) {
-    this->traits_.set_visual_target_temperature_step(this->visual_target_temperature_step_override_);
-  } else
-#endif
-  {
-    this->traits_.set_visual_target_temperature_step(SETPOINT_STEP.f_degc());
-  }
-#ifdef USE_CLIMATE_VISUAL_OVERRIDES
-  if (std::isfinite(this->visual_current_temperature_step_override_)) {
-    this->traits_.set_visual_current_temperature_step(this->visual_current_temperature_step_override_);
-  } else
-#endif
-  {
-    this->traits_.set_visual_current_temperature_step(TEMPERATURE_STEP.f_degc());
-  }
+  this->traits_.set_visual_min_temperature(std::min({this->heat_cool_params.min, this->cool_params.min, this->heat_params.min}).f_degc());  // will be overridden in get_traits()
+  this->traits_.set_visual_max_temperature(std::max({this->heat_cool_params.max, this->cool_params.max, this->heat_params.max}).f_degc());
+  this->traits_.set_visual_target_temperature_step(SETPOINT_STEP.f_degc());
+  this->traits_.set_visual_current_temperature_step(TEMPERATURE_STEP.f_degc());
   this->traits_.set_supported_fan_modes({climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_QUIET});
-  this->traits_.set_supported_custom_fan_modes({
+  // populate local state used in get_traits()
+  this->set_supported_custom_fan_modes({
       daikin_fan_mode_to_cstr(DaikinFan1),
       daikin_fan_mode_to_cstr(DaikinFan2),
       daikin_fan_mode_to_cstr(DaikinFan3),
@@ -95,8 +74,9 @@ void DaikinS21Climate::setup() {
 /**
  * ESPHome Component loop
  *
- * Deferred work when an update occurs.
- * Recalculates the internal setpoint.
+ * Deferred work when an update occurs. Use Component::defer if more work items are added.
+ *
+ * Recalculates the internal setpoint and sends any changes to the unit.
  * Publishes any state changes to Home Assistant.
  */
 void DaikinS21Climate::loop() {
@@ -135,7 +115,7 @@ void DaikinS21Climate::loop() {
       this->unit_setpoint = reported_climate.setpoint;
     }
 
-    // Determine a new target temperature?
+    // Determine if there's any change to the target temperature
     if ((std::isfinite(this->target_temperature) == false) || // controller init or external mode change to a setpoint mode
         (this->unit_setpoint != reported_climate.setpoint)) { // external change to setpoint
       // Assume the reported setpoint (external IR remote change) should be the target temperature
@@ -153,16 +133,19 @@ void DaikinS21Climate::loop() {
       ESP_LOGI(TAG, "Target temperature changed: %.1f -> %.1f",
           this->target_temperature, new_target.f_degc());
       this->target_temperature = new_target.f_degc();
-      this->unit_setpoint = reported_climate.setpoint;  // will be recalculated shortly, but ensure that log statement is sensical
+      this->unit_setpoint = reported_climate.setpoint;  // will be recalculated shortly, but ensure the log statement there is sensical
       do_publish = true;
       update_unit_setpoint = true;
     }
 
-    // Recalculate the unit setpoint if the target temperature changed or it's time to recheck
-    if (update_unit_setpoint || timestamp_passed(App.get_loop_component_start_time(), this->next_offset_check_ms)) {
+    // Periodic sensor-unit offset calculation
+    if ((this->offset_interval == SCHEDULER_DONT_RUN) || timestamp_passed(App.get_loop_component_start_time(), this->next_offset_check_ms)) {
       this->next_offset_check_ms = App.get_loop_component_start_time() + this->offset_interval;
+      update_unit_setpoint = true;
+    }
 
-      // Reuse this flag to mean the setpoint has been updated and should be sent
+    // Setpoint has been flagged for recalculation, see if it results in a change for the unit
+    if (update_unit_setpoint) {
       update_unit_setpoint = this->calc_unit_setpoint(*mode_params, new_temperature);
     }
   } else {
@@ -217,7 +200,12 @@ void DaikinS21Climate::dump_config() {
     ESP_LOGCONFIG(TAG, "  HUMIDITY SENSOR: INVALID UNIT '%s' (must be %%)",
         this->humidity_sensor_->get_unit_of_measurement_ref().c_str());
   }
-  ESP_LOGCONFIG(TAG, "  Setpoint interval: %" PRIu32 "s", this->get_update_interval() / 1000);
+  LOG_UPDATE_INTERVAL(this);
+  if (this->offset_interval == SCHEDULER_DONT_RUN) {
+    ESP_LOGCONFIG(TAG, "  Offset Interval: never");
+  } else {
+    ESP_LOGCONFIG(TAG, "  Offset Interval: %.3fs", this->offset_interval / 1000.0f);
+  }
   for (const climate::ClimateMode mode : {climate::CLIMATE_MODE_HEAT_COOL, climate::CLIMATE_MODE_COOL, climate::CLIMATE_MODE_HEAT}) {
     if (const auto * const params = get_setpoint_mode_params(mode)) {
       ESP_LOGCONFIG(TAG, "  %s parameters\n"

--- a/components/daikin_s21/climate/daikin_s21_climate.h
+++ b/components/daikin_s21/climate/daikin_s21_climate.h
@@ -41,7 +41,7 @@ class DaikinS21Climate : public climate::Climate,
   climate::ClimateTraits traits_{};
   climate::ClimateTraits traits() final { return traits_; };
 
-  bool is_free_run() const { return this->get_update_interval() == 0; }
+  bool is_free_run() const { return this->get_update_interval() == SCHEDULER_DONT_RUN; }
   bool temperature_sensor_unit_is_valid();
   bool use_temperature_sensor();
   DaikinC10 temperature_sensor_degc();

--- a/components/daikin_s21/s21.cpp
+++ b/components/daikin_s21/s21.cpp
@@ -240,42 +240,44 @@ DaikinS21::DaikinS21(DaikinSerial * const serial)
 }
 
 void DaikinS21::setup() {
-  this->reset_queries();
-  this->ready.reset();
-  this->start_poller(); // for reinit
+  // mitigation, remove when 2026.4.1 released
+  if (this->get_update_interval() <= 1) {
+    this->set_update_interval(SCHEDULER_DONT_RUN);
+    this->stop_poller();
+  }
+
+  this->reset_queries();  // importantly schedules initial queries
+  this->defer([this](){ this->trigger_cycle(); });
   this->disable_loop();
 }
 
 /**
  * Component update loop.
  *
- * Used for deferred work. Printing too much in the timer callback context causes warnings about blocking for too long.
+ * Used for deferred work. Use Component::defer if more work items are added.
+ *
+ * Dumps the component state to logs. Printing too much in the timer callback context causes warnings about blocking for too long.
  */
 void DaikinS21::loop() {
-  this->dump_state(); // use Component::defer if more work items are added
+  this->dump_state();
   this->disable_loop();
 }
 
 /**
  * PollingComponent update loop.
  *
- * Disable the polling loop (this function) if configured to free run.
+ * Disable the component polling loop (this function) if configured to free run.
  * It executes once on startup
  *
- * Trigger a cycle.
+ * Trigger a S21 communication cycle.
  */
 void DaikinS21::update() {
-  if (this->is_free_run()) {
-    this->stop_poller();
-  }
   this->trigger_cycle();
 }
 
 void DaikinS21::dump_config() {
-  ESP_LOGCONFIG(TAG, "Daikin S21:\n"
-                     "  Polling interval: %" PRIu32 "ms\n"
-                     "  Debug: %s",
-      this->get_update_interval(), ONOFF(this->debug));
+  ESP_LOGCONFIG(TAG, "  Debug: %s", ONOFF(this->debug));
+  LOG_UPDATE_INTERVAL(this);
 }
 
 /**
@@ -1276,7 +1278,11 @@ void DaikinS21::handle_serial_result(const DaikinSerial::Result result, const st
   if ((result != DaikinSerial::Result::Error) && is_query) {
     // if communication established and all queries are disabled we had comms then they were lost
     if (this->ready[ReadyProtocolDetection] && (std::ranges::count_if(this->queries, DaikinQuery::IsEnabled) == 0)) {
-      this->setup();  // reinitialize in order to prepare for the HVAC unit being reconnected
+      // reinitialize in order to prepare for the HVAC unit being reconnected
+      this->ready.reset();
+      this->reset_queries();
+      this->cycle_active = false;
+      this->defer([this](){ this->trigger_cycle(); });
     } else {
       // advance to next query
       this->active_query = std::ranges::find_if(this->active_query + 1, this->queries.end(), DaikinQuery::IsEnabled);

--- a/components/daikin_s21/s21.h
+++ b/components/daikin_s21/s21.h
@@ -106,7 +106,7 @@ class DaikinS21 : public PollingComponent {
   bool get_mode(DaikinMode mode) const;
   DaikinLEDBrightnessMode get_brightness_mode() const;
   std::span<const uint8_t> get_query_result(std::string_view query_str);
-  auto get_cycle_interval_ms() const { return std::max(this->get_update_interval(), this->cycle_time_ms); }
+  auto get_cycle_interval_ms() const { return std::max(this->cycle_time_ms, this->is_free_run() ? 0 : this->get_update_interval()); }
 
   // callbacks for serial events
   void handle_serial_result(DaikinSerial::Result result, std::span<const uint8_t> response = {});
@@ -117,7 +117,7 @@ class DaikinS21 : public PollingComponent {
 
   // communication state
   void dump_state();
-  bool is_free_run() const { return this->get_update_interval() == 0; }
+  bool is_free_run() const { return this->get_update_interval() == SCHEDULER_DONT_RUN; }
   void trigger_cycle();
   void start_cycle();
   enum ReadyCommand : uint8_t {

--- a/components/daikin_s21/sensor/__init__.py
+++ b/components/daikin_s21/sensor/__init__.py
@@ -9,6 +9,7 @@ from esphome.const import (
     CONF_ENERGY,
     CONF_HUMIDITY,
     CONF_ID,
+    CONF_NEVER,
     CONF_POWER,
     CONF_TARGET_TEMPERATURE,
     DEVICE_CLASS_ENERGY,
@@ -69,7 +70,7 @@ ENERGY_SENSOR_SCHEMA = sensor.sensor_schema(
 CONFIG_SCHEMA = (
     cv.COMPONENT_SCHEMA
     .extend({cv.GenerateID(): cv.declare_id(DaikinS21Sensor)})
-    .extend(cv.polling_component_schema("10s"))
+    .extend(cv.polling_component_schema(CONF_NEVER))
     .extend(S21_PARENT_SCHEMA)
     .extend({
         cv.Optional(CONF_COIL_TEMP): TEMPERATURE_SENSOR_SCHEMA,

--- a/components/daikin_s21/sensor/daikin_s21_sensor.cpp
+++ b/components/daikin_s21/sensor/daikin_s21_sensor.cpp
@@ -6,6 +6,12 @@ namespace esphome::daikin_s21 {
 static const char * const TAG = "daikin_s21.sensor";
 
 void DaikinS21Sensor::setup() {
+  // mitigation, remove when 2026.4.1 released
+  if (this->get_update_interval() <= 1) {
+    this->set_update_interval(SCHEDULER_DONT_RUN);
+    this->stop_poller();
+  }
+
   if (this->is_free_run()) {
     this->get_parent()->update_callbacks.add([this](){ this->enable_loop_soon_any_context(); });  // enable update events from DaikinS21
   }
@@ -15,7 +21,7 @@ void DaikinS21Sensor::setup() {
 /**
  * ESPHome Component loop
  *
- * Deferred work when an update occurs.
+ * Deferred work when an update occurs. Use Component::defer if more work items are added.
  *
  * Publish the sensors and wait for further updates.
  */
@@ -36,6 +42,7 @@ void DaikinS21Sensor::update() {
 }
 
 void DaikinS21Sensor::dump_config() {
+  LOG_UPDATE_INTERVAL(this);
   LOG_SENSOR("", "Energy", this->energy_sensor_);
   LOG_SENSOR("", "Energy Cooling", this->energy_cooling_sensor_);
   LOG_SENSOR("", "Energy Heating", this->energy_heating_sensor_);

--- a/components/daikin_s21/sensor/daikin_s21_sensor.h
+++ b/components/daikin_s21/sensor/daikin_s21_sensor.h
@@ -82,7 +82,7 @@ class DaikinS21Sensor : public PollingComponent,
   }
 
  protected:
-  bool is_free_run() const { return this->get_update_interval() == 0; }
+  bool is_free_run() const { return this->get_update_interval() == SCHEDULER_DONT_RUN; }
 
   sensor::Sensor *energy_sensor_{};
   sensor::Sensor *energy_cooling_sensor_{};

--- a/components/split_uart/split_uart.h
+++ b/components/split_uart/split_uart.h
@@ -34,11 +34,11 @@ class SplitUART : public uart::UARTComponent, public Component {
     return this->rx->read_array(data, len);
   }
 
-  int available() override {
+  size_t available() override {
     return this->rx->available();
   }
 
-  void flush() override {
+  uart::UARTFlushResult flush() override {
     return this->tx->flush();
   }
 


### PR DESCRIPTION
There's a few API updates, but a major problem is an improvement to the ESPHome scheduler that causes a 0s update_interval in a polling component (s21 platform, sensor, climate) to reschedule the poll immediately, which will lead to an infinite loop that ultimately results in a watchdog reset and bootloop. A mitigation is coming in 2026.4.1, but this results in an unnecessarily fast loop with no benefits to this project other than eating up processor cycles. For free run operation, where logic is driven by events limited by UART performance, polling components should use "never" in YAML configuration.

- Use SCHEDULER_DONT_RUN / "never" for free run mode instead of 0
- Extend meaning to offset_interval in climate component
- Use climate component's set_supported_custom_fan_modes to avoid heap allocations when copying traits. Traits are wired up automatically.
- Update split_uart API for recent ESPHome versions. Please, just use the regular ESP_IDF UART and pin schema.

Also:
- Remove unnecessary duplicate override of climate visual limits. I now understand these functions better.
- Use built in update_interval logging facilities