### PR TITLE
Cleanups to binary sensor, schema changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ A big thanks to:
 A short changelog of sorts, I'll keep things here where a user might encounter
 breaking or significant changes, including configuration updates.
 
+* Binary sensor changes: Removed "valve", use unit "active" instead for the
+  same info. Renamed "multizone_conflict" to "multizone_online", inverting
+  logic and changing the device class. Added "system_online" to track all units
+  on a compressor.
 * Bumped minimum ESPHome version to 2026.4.0 in order to address a few issues.
   If you have an `update_interval` of 0s specified in any polling components
   (s21, climate, sensor) please change this to `never` to indicate the intent
@@ -251,12 +255,13 @@ you see nonsense output then we are likely reading random memory. Your debug
 logs can let me blacklist your model and let others avoid this.
 
 * Defrost
-* Active (Actively controlling climate, climate action can tell us this)
-* Online (In a climate controlling mode, climate mode can tell us this)
-* Refrigerant Valve (shadows active?)
-* Short Cycle Lock (3 minute compressor lockout when changing operation)
-* System Defrost (shadows defrost?)
-* Multizone settings conflict
+* Active (Actively controlling climate, climate action can also tell us this)
+* Multizone Online (Other units are in a compressor dependent mode, useful for
+  resolving conflicts affecting this unit)
+* Online (In a climate controlling mode, climate mode can also tell us this)
+* Short Cycle Lock (2:30-3:00 minute compressor lockout when changing activity)
+* System Defrost (shadows defrost? need to wait for winter to determine this)
+* System Online (Any unit is in a compressor dependent mode)
 
 Additional binary sensors:
 
@@ -644,21 +649,21 @@ binary_sensor:
     # unit and system state bitfield derived, not always supported or reliable:
     defrost:
       name: Defrost
+    multizone_online:
+      name: Multizone Online
     online:
       name: Online
-    valve:
-      name: Valve
+    # serial_error:
+    #   name: Serial Error
     short_cycle:
       name: Short Cycle
       device_id: daikin_outdoor
     system_defrost:
       name: System Defrost
       device_id: daikin_outdoor
-    multizone_conflict:
-      name: Multizone Conflict
+    system_online:
+      name: System Online
       device_id: daikin_outdoor
-    # serial_error:
-    #   name: Serial Error
 
 text_sensor:
   - platform: daikin_s21

--- a/components/daikin_s21/binary_sensor/__init__.py
+++ b/components/daikin_s21/binary_sensor/__init__.py
@@ -39,14 +39,14 @@ from .. import (
 DaikinS21BinarySensor = daikin_s21_ns.class_("DaikinS21BinarySensor", cg.Component)
 DaikinS21BinarySensorMode = daikin_s21_ns.class_("DaikinS21BinarySensorMode", binary_sensor.BinarySensor)
 
-CONF_DEFROST = "defrost"
 CONF_ACTIVE = "active"
+CONF_DEFROST = "defrost"
+CONF_MULTIZONE_ONLINE = "multizone_online"
 CONF_ONLINE = "online"
-CONF_VALVE = "valve"
+CONF_SERIAL_ERROR = "serial_error"
 CONF_SHORT_CYCLE = "short_cycle"
 CONF_SYSTEM_DEFROST = "system_defrost"
-CONF_MULTIZONE_CONFLICT = "multizone_conflict"
-CONF_SERIAL_ERROR = "serial_error"
+CONF_SYSTEM_ONLINE = "system_online"
 
 CONFIG_SCHEMA = (
     cv.COMPONENT_SCHEMA
@@ -81,17 +81,20 @@ CONFIG_SCHEMA = (
             DaikinS21BinarySensorMode,
             icon=ICON_ECONO,
         ),
+        cv.Optional(CONF_ACTIVE): binary_sensor.binary_sensor_schema(
+            device_class=DEVICE_CLASS_RUNNING,
+        ),
         cv.Optional(CONF_DEFROST): binary_sensor.binary_sensor_schema(
             device_class=DEVICE_CLASS_COLD,
         ),
-        cv.Optional(CONF_ACTIVE): binary_sensor.binary_sensor_schema(
-            device_class=DEVICE_CLASS_RUNNING,
+        cv.Optional(CONF_MULTIZONE_ONLINE): binary_sensor.binary_sensor_schema(
+            device_class=DEVICE_CLASS_POWER,
         ),
         cv.Optional(CONF_ONLINE): binary_sensor.binary_sensor_schema(
             device_class=DEVICE_CLASS_POWER,
         ),
-        cv.Optional(CONF_VALVE): binary_sensor.binary_sensor_schema(
-            device_class=DEVICE_CLASS_OPENING,
+        cv.Optional(CONF_SERIAL_ERROR): binary_sensor.binary_sensor_schema(
+            device_class=DEVICE_CLASS_PROBLEM,
         ),
         cv.Optional(CONF_SHORT_CYCLE): binary_sensor.binary_sensor_schema(
             device_class=DEVICE_CLASS_LOCK,
@@ -99,11 +102,8 @@ CONFIG_SCHEMA = (
         cv.Optional(CONF_SYSTEM_DEFROST): binary_sensor.binary_sensor_schema(
             device_class=DEVICE_CLASS_COLD,
         ),
-        cv.Optional(CONF_MULTIZONE_CONFLICT): binary_sensor.binary_sensor_schema(
-            device_class=DEVICE_CLASS_LOCK,
-        ),
-        cv.Optional(CONF_SERIAL_ERROR): binary_sensor.binary_sensor_schema(
-            device_class=DEVICE_CLASS_PROBLEM,
+        cv.Optional(CONF_SYSTEM_ONLINE): binary_sensor.binary_sensor_schema(
+            device_class=DEVICE_CLASS_POWER,
         ),
     })
 )
@@ -119,14 +119,14 @@ async def to_code(config):
             cg.add(var.set_mode_sensor(sens))
 
     binary_sensors = (
-        (CONF_DEFROST, var.set_defrost_sensor),
         (CONF_ACTIVE, var.set_active_sensor),
+        (CONF_DEFROST, var.set_defrost_sensor),
+        (CONF_MULTIZONE_ONLINE, var.set_multizone_online_sensor),
         (CONF_ONLINE, var.set_online_sensor),
-        (CONF_VALVE, var.set_valve_sensor),
+        (CONF_SERIAL_ERROR, var.set_serial_error_sensor),
         (CONF_SHORT_CYCLE, var.set_short_cycle_sensor),
         (CONF_SYSTEM_DEFROST, var.set_system_defrost_sensor),
-        (CONF_MULTIZONE_CONFLICT, var.set_multizone_conflict_sensor),
-        (CONF_SERIAL_ERROR, var.set_serial_error_sensor),
+        (CONF_SYSTEM_ONLINE, var.set_system_online_sensor),
     )
     for key, func in binary_sensors:
         if key in config:

--- a/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.cpp
+++ b/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.cpp
@@ -29,17 +29,20 @@ void DaikinS21BinarySensor::loop() {
       mode_sensor->publish_state(this->get_parent()->get_mode(mode_sensor->mode));
     }
   }
+  if (this->active_sensor_ != nullptr) {
+    this->active_sensor_->publish_state(this->get_parent()->get_active());  // unit
+  }
   if (this->defrost_sensor_ != nullptr) {
     this->defrost_sensor_->publish_state(unit.defrost());
   }
-  if (this->active_sensor_ != nullptr) {
-    this->active_sensor_->publish_state(this->get_parent()->get_active());  // unit
+  if (this->multizone_online_sensor_ != nullptr) {
+    this->multizone_online_sensor_->publish_state(system.multizone_online());
   }
   if (this->online_sensor_ != nullptr) {
     this->online_sensor_->publish_state(unit.online());
   }
-  if (this->valve_sensor_ != nullptr) {
-    this->valve_sensor_->publish_state(system.active());  // refrigerant valve
+  if (this->serial_error_sensor_ != nullptr) {
+    this->serial_error_sensor_->publish_state(this->get_parent()->get_serial_error());
   }
   if (this->short_cycle_sensor_ != nullptr) {
     this->short_cycle_sensor_->publish_state(!system.locked());  // invert for Home Assistant locked/unlocked logic
@@ -47,11 +50,8 @@ void DaikinS21BinarySensor::loop() {
   if (this->system_defrost_sensor_ != nullptr) {
     this->system_defrost_sensor_->publish_state(system.defrost());
   }
-  if (this->multizone_conflict_sensor_ != nullptr) {
-    this->multizone_conflict_sensor_->publish_state(!system.multizone_conflict()); // invert for Home Assistant locked/unlocked logic
-  }
-  if (this->serial_error_sensor_ != nullptr) {
-    this->serial_error_sensor_->publish_state(this->get_parent()->get_serial_error());
+  if (this->system_online_sensor_ != nullptr) {
+    this->system_online_sensor_->publish_state(unit.online() || system.multizone_online());
   }
 }
 
@@ -59,14 +59,14 @@ void DaikinS21BinarySensor::dump_config() {
   for (auto mode_sensor : this->mode_sensors_) {
       LOG_BINARY_SENSOR("", "Mode Sensor", mode_sensor);
   }
-  LOG_BINARY_SENSOR("", "Defrost", this->defrost_sensor_);
   LOG_BINARY_SENSOR("", "Active", this->active_sensor_);
+  LOG_BINARY_SENSOR("", "Defrost", this->defrost_sensor_);
+  LOG_BINARY_SENSOR("", "Multizone Online", this->multizone_online_sensor_);
   LOG_BINARY_SENSOR("", "Online", this->online_sensor_);
-  LOG_BINARY_SENSOR("", "Valve", this->valve_sensor_);
+  LOG_BINARY_SENSOR("", "Serial Error", this->serial_error_sensor_);
   LOG_BINARY_SENSOR("", "Short Cycle", this->short_cycle_sensor_);
   LOG_BINARY_SENSOR("", "System Defrost", this->system_defrost_sensor_);
-  LOG_BINARY_SENSOR("", "Multizone Conflict", this->multizone_conflict_sensor_);
-  LOG_BINARY_SENSOR("", "Serial Error", this->serial_error_sensor_);
+  LOG_BINARY_SENSOR("", "System Online", this->system_online_sensor_);
 }
 
 } // namespace esphome::daikin_s21

--- a/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.h
+++ b/components/daikin_s21/binary_sensor/daikin_s21_binary_sensor.h
@@ -31,20 +31,24 @@ class DaikinS21BinarySensor : public Component,
       this->get_parent()->request_readout(DaikinS21::ReadoutSpecialModes);
     }
   }
+  void set_active_sensor(binary_sensor::BinarySensor * const sensor) {
+    this->active_sensor_ = sensor;
+  }
   void set_defrost_sensor(binary_sensor::BinarySensor * const sensor) {
     this->defrost_sensor_ = sensor;
     this->get_parent()->request_readout(DaikinS21::ReadoutUnitStateBits);
   }
-  void set_active_sensor(binary_sensor::BinarySensor * const sensor) {
-    this->active_sensor_ = sensor;
+  void set_multizone_online_sensor(binary_sensor::BinarySensor * const sensor) {
+    this->multizone_online_sensor_ = sensor;
+    this->get_parent()->request_readout(DaikinS21::ReadoutSystemStateBits);
   }
   void set_online_sensor(binary_sensor::BinarySensor * const sensor) {
     this->online_sensor_ = sensor;
     this->get_parent()->request_readout(DaikinS21::ReadoutUnitStateBits);
   }
-  void set_valve_sensor(binary_sensor::BinarySensor * const sensor) {
-    this->valve_sensor_ = sensor;
-    this->get_parent()->request_readout(DaikinS21::ReadoutSystemStateBits);
+  void set_serial_error_sensor(binary_sensor::BinarySensor * const sensor) {
+    this->serial_error_sensor_ = sensor;
+    this->get_parent()->request_readout(DaikinS21::ReadoutErrorStatus);
   }
   void set_short_cycle_sensor(binary_sensor::BinarySensor * const sensor) {
     this->short_cycle_sensor_ = sensor;
@@ -54,25 +58,22 @@ class DaikinS21BinarySensor : public Component,
     this->system_defrost_sensor_ = sensor;
     this->get_parent()->request_readout(DaikinS21::ReadoutSystemStateBits);
   }
-  void set_multizone_conflict_sensor(binary_sensor::BinarySensor * const sensor) {
-    this->multizone_conflict_sensor_ = sensor;
+  void set_system_online_sensor(binary_sensor::BinarySensor * const sensor) {
+    this->system_online_sensor_ = sensor;
+    this->get_parent()->request_readout(DaikinS21::ReadoutUnitStateBits);
     this->get_parent()->request_readout(DaikinS21::ReadoutSystemStateBits);
-  }
-  void set_serial_error_sensor(binary_sensor::BinarySensor * const sensor) {
-    this->serial_error_sensor_ = sensor;
-    this->get_parent()->request_readout(DaikinS21::ReadoutErrorStatus);
   }
 
  protected:
   DaikinS21BinarySensorMode *mode_sensors_[DaikinModeCount]{};
-  binary_sensor::BinarySensor *defrost_sensor_{};
   binary_sensor::BinarySensor *active_sensor_{};
+  binary_sensor::BinarySensor *defrost_sensor_{};
+  binary_sensor::BinarySensor *multizone_online_sensor_{};
   binary_sensor::BinarySensor *online_sensor_{};
-  binary_sensor::BinarySensor *valve_sensor_{};
+  binary_sensor::BinarySensor *serial_error_sensor_{};
   binary_sensor::BinarySensor *short_cycle_sensor_{};
   binary_sensor::BinarySensor *system_defrost_sensor_{};
-  binary_sensor::BinarySensor *multizone_conflict_sensor_{};
-  binary_sensor::BinarySensor *serial_error_sensor_{};
+  binary_sensor::BinarySensor *system_online_sensor_{};
 };
 
 } // namespace esphome::daikin_s21

--- a/components/daikin_s21/daikin_s21_types.h
+++ b/components/daikin_s21/daikin_s21_types.h
@@ -295,10 +295,13 @@ class DaikinUnitState {
 class DaikinSystemState {
  public:
   constexpr DaikinSystemState(const uint8_t value = 0U) : raw(value) {}
+  // this unit:
+  constexpr bool idle() const { return (this->raw & 0x0F) == 0; } // just this unit
   constexpr bool locked() const { return (this->raw & 0x01) != 0; }
-  constexpr bool active() const { return (this->raw & 0x04) != 0; }
+  constexpr bool active() const { return (this->raw & 0x04) != 0; } // todo another active indicator in case UnitState fails
   constexpr bool defrost() const { return (this->raw & 0x08) != 0; }
-  constexpr bool multizone_conflict() const { return (this->raw & 0x20) != 0; }
+  // other units:
+  constexpr bool multizone_online() const { return (this->raw & 0x20) != 0; }
   uint8_t raw{};
 };
 


### PR DESCRIPTION
- Remove "valve" as duplicate information, use unit "active" instead.
- Rename "multizone_conflict" to "multizone_online", inverting reported logic
- Add "system_online" to report on all units

Two units trying to heat aren't in conflict. Should have got that earlier.