### PR TITLE
Gate external setpoint adoption on IR remote activity

### DIFF
--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -99,10 +99,9 @@ void DaikinS21Climate::loop() {
   // the user's remote from one the unit shifted on its own (or a readback artifact).
   // The counter can lag the setpoint readback by a few seconds and increments in
   // unit-specific strides (10 per command observed), so any change counts as activity.
-  // It is also volatile on the unit side: a unit power loss resets it to zero
-  // (observed 1040 -> 10), so a large DROP is expected data, not corruption. Treating
-  // any change as activity deliberately fails open for one pass in that case, which
-  // matches the unit reverting to its own power-on state anyway.
+  // The unit-side counter can also reset to near zero without warning (observed
+  // 1040 -> 10; cause unconfirmed), so a large DROP is expected data, not corruption.
+  // Treating any change as activity deliberately fails open for one pass in that case.
   // A mismatch that arrives before the counter catches up is left unadopted with
   // unit_setpoint unsynced, so adoption completes on a later pass once the counter moves.
   const uint16_t ir_counter = this->get_parent()->get_ir_counter();

--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -68,6 +68,9 @@ void DaikinS21Climate::setup() {
   // initialize setpoint, will be loaded from preferences or unit shortly
   this->target_temperature = NAN;
 
+  // poll the IR counter so remote activity can be distinguished from unit-side setpoint shifts
+  this->get_parent()->request_readout(DaikinS21::ReadoutIRCounter);
+
   // register for update events from DaikinS21
   this->get_parent()->update_callbacks.add([this](){ this->enable_loop_soon_any_context(); });
   this->disable_loop(); // wait for updates
@@ -91,6 +94,17 @@ void DaikinS21Climate::loop() {
   const auto reported_swing = this->get_parent()->get_swing_mode();
   bool do_publish{};
   bool update_unit_setpoint{};
+
+  // IR receiver activity since the last pass. Used to distinguish a setpoint changed by
+  // the user's remote from one the unit shifted on its own (or a readback artifact).
+  // The counter can lag the setpoint readback by a few seconds and increments in
+  // unit-specific strides (10 per command observed), so any change counts as activity.
+  // A mismatch that arrives before the counter catches up is left unadopted with
+  // unit_setpoint unsynced, so adoption completes on a later pass once the counter moves.
+  const uint16_t ir_counter = this->get_parent()->get_ir_counter();
+  const bool ir_activity = this->ir_counter_primed && (ir_counter != this->last_ir_counter);
+  this->last_ir_counter = ir_counter;
+  this->ir_counter_primed = true;
 
   // See if there's a reason to publish an update
   // Temperature and humidity can be noisy, only publish because of them if the component update interval has passed
@@ -119,9 +133,18 @@ void DaikinS21Climate::loop() {
       this->unit_setpoint = reported_climate.setpoint;
     }
 
-    // Determine if there's any change to the target temperature
+    // Determine if there's any change to the target temperature.
+    // A reported setpoint that differs from the last commanded one is only adopted as a new
+    // user target when the IR receiver saw traffic: some units shift their reported setpoint
+    // autonomously (e.g. around thermostat on/off), and serial glitches can drop a command or
+    // corrupt a readback. Without this gate those events masquerade as remote changes and,
+    // combined with a reference sensor offset, re-derive the target from the unit's shifted
+    // value on every occurrence. Units that don't answer the IR counter query keep the old
+    // adopt-always behavior.
     if ((std::isfinite(this->target_temperature) == false) || // controller init or external mode change to a setpoint mode
-        (this->unit_setpoint != reported_climate.setpoint)) { // external change to setpoint
+        ((this->unit_setpoint != reported_climate.setpoint) && // external change to setpoint...
+         (ir_activity || (this->target_resolved == false) || // ...seen alongside remote activity (or still resolving after boot)
+          (this->get_parent()->ir_counter_available() == false)))) { // ...or IR activity is unknowable on this unit
       // Assume the reported setpoint (external IR remote change) should be the target temperature
       auto new_target = reported_climate.setpoint;
       // When first initializing, we don't know if the reported setpoint is from the IR remote or an offset value from a

--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -144,10 +144,15 @@ void DaikinS21Climate::loop() {
     // combined with a reference sensor offset, re-derive the target from the unit's shifted
     // value on every occurrence. Units that don't answer the IR counter query keep the old
     // adopt-always behavior.
-    if ((std::isfinite(this->target_temperature) == false) || // controller init or external mode change to a setpoint mode
-        ((this->unit_setpoint != reported_climate.setpoint) && // external change to setpoint...
-         (ir_activity || (this->target_resolved == false) || // ...seen alongside remote activity (or still resolving after boot)
-          (this->get_parent()->ir_counter_available() == false)))) { // ...or IR activity is unknowable on this unit
+    // The NaN-target arm is gated too: control() nulls the target on OFF, and if the
+    // power-off write is lost on the wire (or the unit lags applying it), the next pass
+    // still reports a setpoint mode - adopting there overwrites the user's target with
+    // the unit's (offset-shifted) setpoint and save_target() persists it. Boot init still
+    // adopts via target_resolved == false.
+    if (((std::isfinite(this->target_temperature) == false) || // controller init or external mode change to a setpoint mode
+         (this->unit_setpoint != reported_climate.setpoint)) && // external change to setpoint...
+        (ir_activity || (this->target_resolved == false) || // ...seen alongside remote activity (or still resolving after boot)
+         (this->get_parent()->ir_counter_available() == false))) { // ...or IR activity is unknowable on this unit
       // Assume the reported setpoint (external IR remote change) should be the target temperature
       auto new_target = reported_climate.setpoint;
       // When first initializing, we don't know if the reported setpoint is from the IR remote or an offset value from a
@@ -174,9 +179,13 @@ void DaikinS21Climate::loop() {
       update_unit_setpoint = true;
     }
 
-    // Setpoint has been flagged for recalculation, see if it results in a change for the unit
+    // Setpoint has been flagged for recalculation, see if it results in a change for the unit.
+    // Never compute from a NaN target: with adoption gated, the target can legitimately be
+    // NaN while a mode transition is in flight, and calc would derive a garbage setpoint
+    // from the NaN cast (violating its precondition).
     if (update_unit_setpoint) {
-      update_unit_setpoint = this->calc_unit_setpoint(*mode_params, new_temperature);
+      update_unit_setpoint = std::isfinite(this->target_temperature) &&
+                             this->calc_unit_setpoint(*mode_params, new_temperature);
     }
   } else {
     // Not a setpoint mode
@@ -463,7 +472,11 @@ void DaikinS21Climate::set_s21_climate() {
   // Command new settings
   this->get_parent()->set_climate_settings({this->mode, this->get_daikin_fan_mode(), this->unit_setpoint});
   if (auto * const mode_params = this->get_setpoint_mode_params(this->mode)) {
-    mode_params->save_target(this->target_temperature);
+    // Never persist a NaN target: the int16 cast turns it into garbage that poisons the
+    // saved dial, and the next mode engage then loads an invalid target.
+    if (std::isfinite(this->target_temperature)) {
+      mode_params->save_target(this->target_temperature);
+    }
   }
 }
 

--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -99,6 +99,10 @@ void DaikinS21Climate::loop() {
   // the user's remote from one the unit shifted on its own (or a readback artifact).
   // The counter can lag the setpoint readback by a few seconds and increments in
   // unit-specific strides (10 per command observed), so any change counts as activity.
+  // It is also volatile on the unit side: a unit power loss resets it to zero
+  // (observed 1040 -> 10), so a large DROP is expected data, not corruption. Treating
+  // any change as activity deliberately fails open for one pass in that case, which
+  // matches the unit reverting to its own power-on state anyway.
   // A mismatch that arrives before the counter catches up is left unadopted with
   // unit_setpoint unsynced, so adoption completes on a later pass once the counter moves.
   const uint16_t ir_counter = this->get_parent()->get_ir_counter();

--- a/components/daikin_s21/climate/daikin_s21_climate.h
+++ b/components/daikin_s21/climate/daikin_s21_climate.h
@@ -55,6 +55,8 @@ class DaikinS21Climate : public climate::Climate,
   sensor::Sensor *temperature_sensor_{};
   sensor::Sensor *humidity_sensor_{};
   DaikinC10 unit_setpoint{TEMPERATURE_INVALID};
+  uint16_t last_ir_counter{};
+  bool ir_counter_primed{};
   bool check_sensors{true};
   bool check_offset{true};
   bool freerun_offset{};

--- a/components/daikin_s21/s21.cpp
+++ b/components/daikin_s21/s21.cpp
@@ -533,6 +533,14 @@ std::span<const uint8_t> DaikinS21::get_query_result(std::string_view query_str)
   return this->get_query(query_str).value();
 }
 
+/**
+ * Whether the unit is answering the IR counter query, making the counter usable
+ * as an indicator of IR remote activity.
+ */
+bool DaikinS21::ir_counter_available() {
+  return this->get_query(StateQuery::IRCounter).success();
+}
+
 void DaikinS21::dump_state() {
   ESP_LOGD(TAG, "Ready: %lX  Protocol: %" PRIu8 ".%" PRIu8 "  ModelV0: %04" PRIX16 "  ModelV2: %04" PRIX16 "  ModelV3: %04" PRIX16,
       this->ready.to_ulong(),

--- a/components/daikin_s21/s21.h
+++ b/components/daikin_s21/s21.h
@@ -104,6 +104,7 @@ class DaikinS21 : public PollingComponent {
   bool get_mode(DaikinMode mode) const;
   DaikinLEDBrightnessMode get_brightness_mode() const;
   std::span<const uint8_t> get_query_result(std::string_view query_str);
+  bool ir_counter_available();
   auto get_cycle_interval_ms() const { return std::max(this->cycle_time_ms, this->is_free_run() ? 0 : this->get_update_interval()); }
 
  protected:


### PR DESCRIPTION
The climate component adopts any reported setpoint that differs from the last commanded one as a new user target. Two non-user sources produce exactly that mismatch: units that shift their reported setpoint autonomously (observed on an FTXQ09ASBU9, protocol 3.40), and serial glitches that drop a command or corrupt a readback (command staging is also reset on serial errors).

When an external reference sensor with a live offset is in use, each false adoption re-derives the target from the unit's shifted value and re-applies the offset. The target ratchets to the mode minimum within a few thermostat cycles: on the unit above, a 22.2C target walked to the 18C floor while the unit's IR counter was static the entire time, i.e. no remote was involved.

Fix: track the IR command counter (FG query) between update passes and only adopt a changed reported setpoint when the counter moved. Any counter change counts as activity (units increment in strides, 10 per command observed), and the counter can lag the setpoint readback by a few seconds -- an early mismatch is left unadopted with the tracked setpoint unsynced, so adoption completes on a later pass once the counter catches up. The unit-side counter can also reset to near zero without warning, so a large drop is treated the same as any other change, deliberately failing open for a single pass. The climate component now requests the IR counter readout itself. Initial post-boot target resolution is unchanged, and units that do not answer FG keep the previous adopt-always behavior.

Validated and compiled against ESPHome 2026.6.4.