### PR TITLE
Add setpoint_dither option to disable directional setpoint rounding

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ The main control interface. Supported features:
     target temperature at a steady state so I add a +1.0C offset here.
   * Range limits for values sent to the unit. Defaults should work fine, but if
     your unit is different they can be overridden.
+* Optional `setpoint_dither` (default `true`). When the ideal setpoint falls
+  between the unit's 0.5C steps, the commanded value is rounded in the
+  direction of change so it oscillates over the ideal value over time. Set to
+  `false` to always round down instead, trading the oscillation (and its
+  periodic setpoint writes while the temperature hovers around the target) for
+  a steady command up to half a step below the ideal value.
 
 Daikin's modes don't neatly fit into the discrete "preset" category modelled by
 ESPHome as they function more like mode modifiers. Switches are provided for

--- a/README.md
+++ b/README.md
@@ -112,11 +112,11 @@ The main control interface. Supported features:
   * Range limits for values sent to the unit. Defaults should work fine, but if
     your unit is different they can be overridden.
 * Optional `setpoint_dither` (default `true`). When the ideal setpoint falls
-  between the unit's 0.5C steps, the commanded value is rounded in the
-  direction of change so it oscillates over the ideal value over time. Set to
-  `false` to always round down instead, trading the oscillation (and its
-  periodic setpoint writes while the temperature hovers around the target) for
-  a steady command up to half a step below the ideal value.
+  between the unit's steps, the commanded value is rounded in the direction of
+  change so it oscillates over the ideal value over time. Set to `false` to
+  round to the nearest step instead, trading the oscillation (and its periodic
+  setpoint writes while the temperature hovers around the target) for a steady
+  command within half a step of the ideal value.
 
 Daikin's modes don't neatly fit into the discrete "preset" category modelled by
 ESPHome as they function more like mode modifiers. Switches are provided for

--- a/components/daikin_s21/climate/__init__.py
+++ b/components/daikin_s21/climate/__init__.py
@@ -40,6 +40,7 @@ SUPPORTED_CLIMATE_MODES_OPTIONS = {
 validate_supported_climate_mode = cv.enum(SUPPORTED_CLIMATE_MODES_OPTIONS, upper=True)
 
 CONF_OFFSET_INTERVAL = "offset_interval"
+CONF_SETPOINT_DITHER = "setpoint_dither"
 
 CONFIG_MODE_SCHEMA = cv.Schema({
     cv.Optional(CONF_OFFSET, default="0"): cv.temperature,
@@ -53,6 +54,7 @@ CONFIG_SCHEMA = (
     .extend(S21_PARENT_SCHEMA)
     .extend({
         cv.Optional(CONF_OFFSET_INTERVAL, default="5min"): cv.update_interval,
+        cv.Optional(CONF_SETPOINT_DITHER, default=True): cv.boolean,
         cv.Optional(CONF_SENSOR): cv.use_id(sensor.Sensor),
         cv.Optional(CONF_HUMIDITY_SENSOR): cv.use_id(sensor.Sensor),
         cv.Optional(CONF_SUPPORTED_MODES, default=list(SUPPORTED_CLIMATE_MODES_OPTIONS)): cv.ensure_list(validate_supported_climate_mode),
@@ -69,6 +71,7 @@ async def to_code(config):
     await cg.register_parented(var, config[CONF_S21_ID])
 
     cg.add(var.set_offset_interval(config[CONF_OFFSET_INTERVAL]))
+    cg.add(var.set_setpoint_dither(config[CONF_SETPOINT_DITHER]))
 
     if CONF_SENSOR in config:
         sens = await cg.get_variable(config[CONF_SENSOR])

--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -367,14 +367,16 @@ bool DaikinS21Climate::calc_unit_setpoint(const DaikinSetpointMode& mode_params,
   auto new_unit_setpoint = static_cast<DaikinC10>(this->target_temperature) + sensor_offset + mode_params.offset;
 
   // Round to Daikin's internal setpoint resolution
-  // When the ideal setpoint is between steps force it in the direction of change by controlling rounding. Over time it should oscillate over the ideal setpoint.
-  if (new_unit_setpoint < unit_temperature) {
-    // commanding the unit lower, round down
-  } else if (new_unit_setpoint > unit_temperature) {
-    // commanding the unit higher, round up by adding almost a full step
-    new_unit_setpoint = new_unit_setpoint + (SETPOINT_STEP - 1);
-  } else {
-    // no difference, no rounding necessary
+  if (this->setpoint_dither) {
+    // When the ideal setpoint is between steps force it in the direction of change by controlling rounding. Over time it should oscillate over the ideal setpoint.
+    if (new_unit_setpoint < unit_temperature) {
+      // commanding the unit lower, round down
+    } else if (new_unit_setpoint > unit_temperature) {
+      // commanding the unit higher, round up by adding almost a full step
+      new_unit_setpoint = new_unit_setpoint + (SETPOINT_STEP - 1);
+    } else {
+      // no difference, no rounding necessary
+    }
   }
   new_unit_setpoint = (new_unit_setpoint / SETPOINT_STEP) * SETPOINT_STEP;  // complete round by truncating fractional component of step
 

--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -377,6 +377,11 @@ bool DaikinS21Climate::calc_unit_setpoint(const DaikinSetpointMode& mode_params,
     } else {
       // no difference, no rounding necessary
     }
+  } else {
+    // No dither: round to the nearest step. Truncation alone would bias the command
+    // down by up to a full step, which compounds with units that already regulate
+    // below their commanded setpoint.
+    new_unit_setpoint = new_unit_setpoint + (SETPOINT_STEP / 2);
   }
   new_unit_setpoint = (new_unit_setpoint / SETPOINT_STEP) * SETPOINT_STEP;  // complete round by truncating fractional component of step
 

--- a/components/daikin_s21/climate/daikin_s21_climate.h
+++ b/components/daikin_s21/climate/daikin_s21_climate.h
@@ -31,6 +31,7 @@ class DaikinS21Climate : public climate::Climate,
   void control(const climate::ClimateCall &call) final;
 
   void set_offset_interval(uint32_t offset_interval);
+  void set_setpoint_dither(const bool dither) { this->setpoint_dither = dither; }
   void set_supported_modes(climate::ClimateModeMask modes);
   void set_supported_swing_modes(climate::ClimateSwingModeMask swing_modes);
   void set_temperature_reference_sensor(sensor::Sensor * const sensor) { this->temperature_sensor_ = sensor; }
@@ -55,6 +56,7 @@ class DaikinS21Climate : public climate::Climate,
   sensor::Sensor *temperature_sensor_{};
   sensor::Sensor *humidity_sensor_{};
   DaikinC10 unit_setpoint{TEMPERATURE_INVALID};
+  bool setpoint_dither{true};
   bool check_sensors{true};
   bool check_offset{true};
   bool freerun_offset{};


### PR DESCRIPTION
For targets that fall between the unit's 0.5C steps (e.g. 72F = 22.22C), the directional rounding intentionally oscillates the commanded setpoint between the two adjacent steps so the time-average approaches the ideal value. The side effect is a setpoint write every time the inside temperature crosses the target -- indefinitely, with no user change, for any between-step target.

This adds a climate option `setpoint_dither` (default `true`, preserving current behavior). When `false`, the ideal setpoint is rounded to the nearest step: the commanded value is stable for a given target and offset, and recalculation only writes when something actually changes. An earlier revision of this PR truncated downward instead, which biased the command low by up to a full step and compounded with units that regulate their internal sensor below the commanded setpoint. Documented in the README.

Validated against ESPHome 2026.6.4 with the option exercised.