### PR TITLE
Fix build on ESP8266 (avoid compile error on GCC 10)

### DIFF
--- a/components/daikin_s21/daikin_s21_types.h
+++ b/components/daikin_s21/daikin_s21_types.h
@@ -89,7 +89,7 @@ using uint8_array = std::array<uint8_t, N>;
  * @param encoding encoding to look up
  * @return associated index enum value
  */
-template <typename T, const uint8_array &encoding_table>
+template <typename T, const auto &encoding_table>
 constexpr T encoding_to_enum(const uint8_t encoding) {
   const auto iter = std::ranges::find(encoding_table, encoding);
   if (iter != std::ranges::end(encoding_table)) {
@@ -108,7 +108,7 @@ constexpr T encoding_to_enum(const uint8_t encoding) {
  * @param index index to look up
  * @return associated encoding
  */
-template <typename T, const uint8_array &encoding_table>
+template <typename T, const auto &encoding_table>
 constexpr uint8_t enum_to_encoding(const T index) {
   if (index < encoding_table.size()) {
     return encoding_table[index];


### PR DESCRIPTION
I have 4 daikin units with esp8266 modules, and I ran into a compile error when i tried to upgrade esphome on them. This fix resolves that issue and I can confirm esphome compiles, flashes, and the esp modules communicate with my daikin units just fine.

Looks like ESP8266 targets build with platformio/espressif8266, whose newest toolchain is toolchain-xtensa 2.100300.220621 -- GCC 10.3.0. Every translation unit that includes daikin_s21_types.h therefore fails:

  daikin_s21_types.h:92:23: error: template placeholder type
  'const uint8_array<...auto...>' must be followed by a simple
  declarator-id

Declaring the parameter as `const auto &` is plain C++17 and compiles on GCC 10.3. Call sites are unchanged and the generated code is identical; the only thing given up is the compile-time constraint that the table is a std::array<uint8_t, N>.

Verified on ESPHome 2026.7.4, board esp01_1m, Arduino framework: RAM 40.4% (33128/81920), Flash 44.9% (459743/1023984). Updated successfully via OTA.